### PR TITLE
Add errcheck linter and fix up the problems it found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ go-meta-linter: vendor/.up-to-date $(GENERATED_GO_FILES)
 	                                --deadline=300s \
 	                                --disable-all \
 	                                --enable=goimports \
+	                                --enable=errcheck \
 	                                --vendor ./...
 
 .PHONY: static-checks

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -544,7 +544,8 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 
 		It("should clean up if the hello doesn't get sent", func() {
 			expectGaugeValue("typha_connections_active", 1.0)
-			rawConn.Close()
+			err := rawConn.Close()
+			Expect(err).ToNot(HaveOccurred())
 			expectGaugeValue("typha_connections_active", 0.0)
 		})
 
@@ -576,7 +577,8 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 			})
 
 			It("should disconnect a client that sends a garbage update", func() {
-				rawConn.Write([]byte("dsjfkldjsklfajdskjfk;dajskfjaoirefmuweioufijsdkfjkdsjkfjasd;"))
+				_, err := rawConn.Write([]byte("dsjfkldjsklfajdskjfk;dajskfjaoirefmuweioufijsdkfjkdsjkfjasd;"))
+				log.WithError(err).Info("Sent garbage to server")
 				// We don't get dropped as quickly as above because the gob decoder doesn't raise an
 				// error for the above data (presumably, it's still waiting for more data to decode).
 				// We should still get dropped byt he ping timeout though...

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -134,7 +134,6 @@ type Config struct {
 	// nameToSource tracks where we loaded each config param from.
 	sourceToRawConfig map[Source]map[string]string
 	rawValues         map[string]string
-	FatalErr          error
 
 	numIptablesBitsAllocated int
 }
@@ -210,7 +209,6 @@ func (config *Config) resolve() (changed bool, err error) {
 					log.Errorf(
 						"Failed to parse value for %v: %v from source %v. %v",
 						name, rawValue, source, err)
-					config.FatalErr = err
 					return
 				}
 				value = metadata.ZeroValue
@@ -222,7 +220,6 @@ func (config *Config) resolve() (changed bool, err error) {
 					logCxt := log.WithError(err).WithField("source", source)
 					if metadata.DieOnParseFailure {
 						logCxt.Error("Invalid (required) config value.")
-						config.FatalErr = err
 						return
 					} else {
 						logCxt.WithField("default", metadata.Default).Warn(
@@ -304,10 +301,6 @@ func (config *Config) Validate() (err error) {
 		if config.EtcdAddr == "" {
 			err = errors.New("EtcdEndpoints and EtcdAddr both missing")
 		}
-	}
-
-	if err != nil {
-		config.FatalErr = err
 	}
 	return
 }

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -134,7 +134,7 @@ type Config struct {
 	// nameToSource tracks where we loaded each config param from.
 	sourceToRawConfig map[Source]map[string]string
 	rawValues         map[string]string
-	Err               error
+	FatalErr          error
 
 	numIptablesBitsAllocated int
 }
@@ -210,7 +210,7 @@ func (config *Config) resolve() (changed bool, err error) {
 					log.Errorf(
 						"Failed to parse value for %v: %v from source %v. %v",
 						name, rawValue, source, err)
-					config.Err = err
+					config.FatalErr = err
 					return
 				}
 				value = metadata.ZeroValue
@@ -222,7 +222,7 @@ func (config *Config) resolve() (changed bool, err error) {
 					logCxt := log.WithError(err).WithField("source", source)
 					if metadata.DieOnParseFailure {
 						logCxt.Error("Invalid (required) config value.")
-						config.Err = err
+						config.FatalErr = err
 						return
 					} else {
 						logCxt.WithField("default", metadata.Default).Warn(
@@ -307,7 +307,7 @@ func (config *Config) Validate() (err error) {
 	}
 
 	if err != nil {
-		config.Err = err
+		config.FatalErr = err
 	}
 	return
 }

--- a/pkg/config/config_params_test.go
+++ b/pkg/config/config_params_test.go
@@ -26,14 +26,16 @@ import (
 var _ = DescribeTable("Config parsing",
 	func(key, value string, expected interface{}, errorExpected ...bool) {
 		config := New()
-		config.UpdateFrom(map[string]string{key: value},
+		_, err := config.UpdateFrom(map[string]string{key: value},
 			EnvironmentVariable)
 		newVal := reflect.ValueOf(config).Elem().FieldByName(key).Interface()
 		Expect(newVal).To(Equal(expected))
 		if len(errorExpected) > 0 && errorExpected[0] {
-			Expect(config.Err).To(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(config.FatalErr).To(HaveOccurred())
 		} else {
-			Expect(config.Err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.FatalErr).NotTo(HaveOccurred())
 		}
 	},
 

--- a/pkg/config/config_params_test.go
+++ b/pkg/config/config_params_test.go
@@ -32,10 +32,8 @@ var _ = DescribeTable("Config parsing",
 		Expect(newVal).To(Equal(expected))
 		if len(errorExpected) > 0 && errorExpected[0] {
 			Expect(err).To(HaveOccurred())
-			Expect(config.FatalErr).To(HaveOccurred())
 		} else {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config.FatalErr).NotTo(HaveOccurred())
 		}
 	},
 

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -30,11 +30,9 @@
 //
 // Then feed it to the config object:
 //
-//    config.UpdateFrom(envConfig, config.EnvironmentVariable)
-//    config.UpdateFrom(fileConfig, config.ConfigFile)
-//
-// The UpdateFrom() method returns an error, but, as a convenience, it also
-// stores the error in config.FatalErr.
+//    changed, err := config.UpdateFrom(envConfig, config.EnvironmentVariable)
+//    ...
+//    changed, err = config.UpdateFrom(fileConfig, config.ConfigFile)
 //
 // Config inheritance
 //

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2016-2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // The config package provides config inheritance for Typha.
 //
 // It supports loading config from various sources, parsing and validating the
@@ -20,7 +34,7 @@
 //    config.UpdateFrom(fileConfig, config.ConfigFile)
 //
 // The UpdateFrom() method returns an error, but, as a convenience, it also
-// stores the error in config.Err.
+// stores the error in config.FatalErr.
 //
 // Config inheritance
 //

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -156,20 +156,14 @@ configRetry:
 		// Parse and merge the local config.
 		_, err = configParams.UpdateFrom(envConfig, config.EnvironmentVariable)
 		if err != nil {
-			log.WithError(err).Warn("Error parsing environment variables. Checking if it's fatal.")
-		}
-		if configParams.FatalErr != nil {
-			log.WithError(configParams.FatalErr).WithField("configFile", t.ConfigFilePath).Error(
+			log.WithError(err).WithField("configFile", t.ConfigFilePath).Error(
 				"Failed to parse configuration environment variable")
 			time.Sleep(1 * time.Second)
 			continue configRetry
 		}
 		_, err = configParams.UpdateFrom(fileConfig, config.ConfigFile)
 		if err != nil {
-			log.WithError(err).Warn("Error parsing config file. Checking if it's fatal.")
-		}
-		if configParams.FatalErr != nil {
-			log.WithError(configParams.FatalErr).WithField("configFile", t.ConfigFilePath).Error(
+			log.WithError(err).WithField("configFile", t.ConfigFilePath).Error(
 				"Failed to parse configuration file")
 			time.Sleep(1 * time.Second)
 			continue configRetry
@@ -186,8 +180,8 @@ configRetry:
 		}
 
 		err = configParams.Validate()
-		if err != nil || configParams.FatalErr != nil {
-			log.WithError(configParams.FatalErr).Error(
+		if err != nil {
+			log.WithError(err).Error(
 				"Failed to parse/validate configuration from datastore.")
 			time.Sleep(1 * time.Second)
 			continue configRetry

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -98,7 +98,8 @@ var _ = Describe("Daemon", func() {
 			Expect(loggingConfigured).To(BeTrue())
 		})
 		AfterEach(func() {
-			os.Remove(configFile.Name())
+			err := os.Remove(configFile.Name())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should load the configuration and connect to the datastore", func() {
@@ -141,7 +142,8 @@ var _ = Describe("Daemon", func() {
 				clientCancelFn()
 				client.Finished.Wait()
 			}()
-			client.Start(clientCxt)
+			err := client.Start(clientCxt)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Send in an update at the top of the processing pipeline.
 			d.SyncerToValidator.OnStatusUpdated(bapi.InSync)

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -379,7 +379,7 @@ func NewSyslogDestination(
 		channel: c,
 		writeLog: func(ql QueuedLog) error {
 			if ql.NumSkippedLogs > 0 {
-				writer.Warning(fmt.Sprintf("... dropped %d logs ...\n",
+				_ = writer.Warning(fmt.Sprintf("... dropped %d logs ...\n",
 					ql.NumSkippedLogs))
 			}
 			err := writeToSyslog(writer, ql)

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -75,7 +75,10 @@ func (s *SyncerClient) Start(cxt context.Context) error {
 		s.logCxt.Info("Typha client Context asked us to exit")
 		// Close the connection.  This will trigger the main loop to exit if it hasn't
 		// already.
-		s.c.Close()
+		err := s.c.Close()
+		if err != nil {
+			log.WithError(err).Warn("Ignoring error from Close during shut-down of client.")
+		}
 		// Broadcast that we're finished.
 		s.Finished.Done()
 	}()
@@ -98,7 +101,10 @@ func (s *SyncerClient) connect(cxt context.Context) error {
 	}
 	if cxt.Err() != nil {
 		if s.c != nil {
-			s.c.Close()
+			err := s.c.Close()
+			if err != nil {
+				log.WithError(err).Warn("Ignoring error from Close during shut-down of client.")
+			}
 		}
 		return cxt.Err()
 	}


### PR DESCRIPTION
## Description
Add the errcheck linter to those that we run.  `errcheck` checks that all error return values are handled.  Fix the bugs that it turned up.
