### PR TITLE
Add connection count governing.

### DIFF
--- a/cmd/calico-typha/typha.go
+++ b/cmd/calico-typha/typha.go
@@ -38,6 +38,7 @@ import (
 	"github.com/projectcalico/typha/pkg/buildinfo"
 	"github.com/projectcalico/typha/pkg/calc"
 	"github.com/projectcalico/typha/pkg/config"
+	"github.com/projectcalico/typha/pkg/jitter"
 	"github.com/projectcalico/typha/pkg/k8s"
 	"github.com/projectcalico/typha/pkg/logutils"
 	"github.com/projectcalico/typha/pkg/snapcache"
@@ -211,7 +212,9 @@ configRetry:
 	server.Start(context.Background())
 	if configParams.ConnectionRebalancingMode == "kubernetes" {
 		log.Info("Kubernetes connection rebalancing is enabled, starting k8s poll goroutine.")
-		go k8s.PollK8sForConnectionLimit(configParams, server)
+		k8sAPI := k8s.NewK8sAPI()
+		ticker := jitter.NewTicker(configParams.K8sServicePollIntervalSecs, configParams.K8sServicePollIntervalSecs/10)
+		go k8s.PollK8sForConnectionLimit(context.Background(), configParams, ticker.C, k8sAPI, server)
 	}
 	log.Info("Started the datastore Syncer/cache layer/server.")
 

--- a/cmd/calico-typha/typha.go
+++ b/cmd/calico-typha/typha.go
@@ -33,14 +33,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"math"
-
 	"github.com/projectcalico/libcalico-go/lib/backend"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/typha/pkg/buildinfo"
 	"github.com/projectcalico/typha/pkg/calc"
 	"github.com/projectcalico/typha/pkg/config"
-	"github.com/projectcalico/typha/pkg/jitter"
 	"github.com/projectcalico/typha/pkg/k8s"
 	"github.com/projectcalico/typha/pkg/logutils"
 	"github.com/projectcalico/typha/pkg/snapcache"
@@ -200,6 +197,8 @@ configRetry:
 			MaxFallBehind:           configParams.ServerMaxFallBehindSecs,
 			PingInterval:            configParams.ServerPingIntervalSecs,
 			PongTimeout:             configParams.ServerPongTimeoutSecs,
+			DropInterval:            configParams.ConnectionDropIntervalSecs,
+			MaxConns:                configParams.MaxConnectionsUpperLimit,
 		},
 	)
 
@@ -210,7 +209,10 @@ configRetry:
 	go validatorToCache.SendTo(cache)
 	cache.Start(context.Background())
 	server.Start(context.Background())
-	go watchK8s(server)
+	if configParams.ConnectionRebalancingMode == "kubernetes" {
+		log.Info("Kubernetes connection rebalancing is enabled, starting k8s poll goroutine.")
+		go k8s.PollK8sForConnectionLimit(configParams, server)
+	}
 	log.Info("Started the datastore Syncer/cache layer/server.")
 
 	if configParams.PrometheusMetricsEnabled {
@@ -230,51 +232,6 @@ configRetry:
 		case <-usr1SignalChan:
 			log.Info("Received SIGUSR1, emitting heap profile")
 			dumpHeapMemoryProfile(configParams)
-		}
-	}
-}
-
-func watchK8s(server *syncserver.Server) {
-	const enoughForAnyone = math.MaxInt32
-	ticker := jitter.NewTicker(time.Minute, 10*time.Second)
-	activeTarget := enoughForAnyone
-	for {
-		<-ticker.C
-		numTyphas, err := k8s.GetNumTyphas("kube-system", "calico-typha", "calico-typha")
-		if err != nil || numTyphas <= 0 {
-			log.WithError(err).Warn("Failed to get number of Typhas, removing connection limit")
-			server.SetMaxConns(enoughForAnyone)
-			time.Sleep(30 * time.Second)
-		}
-		numNodes, err := k8s.GetNumNodes()
-		if err != nil || numNodes < 0 {
-			log.WithError(err).Warn("Failed to get number of nodes, removing connection limit")
-			server.SetMaxConns(enoughForAnyone)
-			time.Sleep(30 * time.Second)
-		}
-		target := 100
-		if numTyphas <= 1 {
-			target = enoughForAnyone
-		} else {
-			// Make sure we can accept the load if one of the other Typhas dies.
-			candidate := int(1.2 * float64(numNodes) / float64(numTyphas-1))
-			if candidate > target {
-				target = candidate
-			}
-			candidate = numNodes/(numTyphas-1) + 50
-			if candidate > target {
-				target = candidate
-			}
-		}
-
-		if target != activeTarget {
-			log.WithFields(log.Fields{
-				"numTyphas": numTyphas,
-				"numNodes":  numNodes,
-				"newTarget": target,
-			}).Info("Calculated new target number of max connections.")
-			server.SetMaxConns(target)
-			activeTarget = target
 		}
 	}
 }

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -119,6 +119,15 @@ type Config struct {
 	DebugMemoryProfilePath  string `config:"file;;"`
 	DebugDisableLogDropping bool   `config:"bool;false"`
 
+	ConnectionRebalancingMode  string        `config:"oneof(none,kubernetes);none"`
+	ConnectionDropIntervalSecs time.Duration `config:"seconds;1"`
+	MaxConnectionsUpperLimit   int           `config:"int(1,);10000"`
+	MaxConnectionsLowerLimit   int           `config:"int(1,);100"`
+	K8sServicePollIntervalSecs time.Duration `config:"seconds;30"`
+	K8sNamespace               string        `config:"string;kube-system"`
+	K8sServiceName             string        `config:"string;calico-typha"`
+	K8sPortName                string        `config:"string;calico-typha"`
+
 	// State tracking.
 
 	// nameToSource tracks where we loaded each config param from.

--- a/pkg/k8s/k8s_suite_test.go
+++ b/pkg/k8s/k8s_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
+func TestK8s(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s Suite")
+}

--- a/pkg/k8s/lookup.go
+++ b/pkg/k8s/lookup.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"errors"
+
+	log "github.com/Sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/projectcalico/typha/pkg/set"
+)
+
+var ErrServiceNotReady = errors.New("service not ready")
+
+func GetNumTyphas(namespace, serviceName, portName string) (int, error) {
+	// If we get here, we need to look up the Typha service using the k8s API.
+	// TODO Typha: support Typha lookup without using rest.InClusterConfig().
+	k8sconf, err := rest.InClusterConfig()
+	if err != nil {
+		log.WithError(err).Error("Unable to create Kubernetes config.")
+		return 0, err
+	}
+	clientset, err := kubernetes.NewForConfig(k8sconf)
+	if err != nil {
+		log.WithError(err).Error("Unable to create Kubernetes client set.")
+		return 0, err
+	}
+
+	epClient := clientset.CoreV1().Endpoints(namespace)
+	ep, err := epClient.Get(serviceName, v1.GetOptions{})
+	if err != nil {
+		log.WithError(err).Error("Failed to get Typha endpoint from Kubernetes")
+	}
+
+	ips := set.New()
+	for _, s := range ep.Subsets {
+		found := false
+		for _, port := range s.Ports {
+			if port.Name == portName {
+				found = true
+				break
+			}
+		}
+		if found {
+			for _, ip := range s.Addresses {
+				ips.Add(ip.IP)
+			}
+		}
+	}
+	return ips.Len(), nil
+}
+
+func GetNumNodes() (int, error) {
+	// If we get here, we need to look up the Typha service using the k8s API.
+	// TODO Typha: support Typha lookup without using rest.InClusterConfig().
+	k8sconf, err := rest.InClusterConfig()
+	if err != nil {
+		log.WithError(err).Error("Unable to create Kubernetes config.")
+		return 0, err
+	}
+	clientset, err := kubernetes.NewForConfig(k8sconf)
+	if err != nil {
+		log.WithError(err).Error("Unable to create Kubernetes client set.")
+		return 0, err
+	}
+
+	noClient := clientset.CoreV1().Nodes()
+	list, err := noClient.List(v1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	return len(list.Items), nil
+}

--- a/pkg/k8s/rebalance.go
+++ b/pkg/k8s/rebalance.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/projectcalico/typha/pkg/config"
+	"github.com/projectcalico/typha/pkg/jitter"
+)
+
+type maxConnsAPI interface {
+	SetMaxConns(numConns int)
+}
+
+func PollK8sForConnectionLimit(configParams *config.Config, server maxConnsAPI) {
+	logCxt := log.WithField("thread", "k8s-poll")
+	logCxt.Info("Kubernetes poll goroutine started.")
+	ticker := jitter.NewTicker(configParams.K8sServicePollIntervalSecs, configParams.K8sServicePollIntervalSecs/10)
+	activeTarget := configParams.MaxConnectionsUpperLimit
+	for {
+		<-ticker.C
+		// Get the number of Typhas in the service.
+		numTyphas, err := GetNumTyphas(
+			configParams.K8sNamespace,
+			configParams.K8sServiceName,
+			configParams.K8sPortName,
+		)
+		if err != nil || numTyphas <= 0 {
+			logCxt.WithError(err).Warn("Failed to get number of Typhas, removing connection limit")
+			server.SetMaxConns(configParams.MaxConnectionsUpperLimit)
+			continue
+		}
+		// Get the number of nodes as an estimate for the number of Felix connections we should expect.
+		numNodes, err := GetNumNodes()
+		if err != nil || numNodes <= 0 {
+			logCxt.WithError(err).Warn("Failed to get number of nodes, removing connection limit")
+			server.SetMaxConns(configParams.MaxConnectionsUpperLimit)
+			continue
+		}
+
+		reason := "configured lower limit"
+		target := configParams.MaxConnectionsLowerLimit
+		if numTyphas <= 1 {
+			reason = "lone typha"
+			target = configParams.MaxConnectionsUpperLimit
+		} else {
+			candidate := 1 + numNodes*120/(numTyphas-1)/100
+			if candidate > target {
+				reason = "fraction+20%"
+				target = candidate
+			}
+		}
+		if target > configParams.MaxConnectionsUpperLimit {
+			reason = "configured upper limit"
+			target = configParams.MaxConnectionsUpperLimit
+		}
+
+		if target != activeTarget {
+			logCxt.WithFields(log.Fields{
+				"numTyphas": numTyphas,
+				"numNodes":  numNodes,
+				"newLimit":  target,
+				"reason":    reason,
+			}).Info("Calculated new connection limit.")
+			server.SetMaxConns(target)
+			activeTarget = target
+		}
+	}
+}

--- a/pkg/k8s/rebalance_test.go
+++ b/pkg/k8s/rebalance_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s_test
+
+import (
+	. "github.com/projectcalico/typha/pkg/k8s"
+
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/typha/pkg/config"
+)
+
+var _ = DescribeTable("CalculateMaxConnLimit tests",
+	func(numTyphas, numNodes, expectedNumber int, expectedReason string) {
+		configParams := &config.Config{
+			MaxConnectionsLowerLimit: 11,
+			MaxConnectionsUpperLimit: 101,
+		}
+		num, reason := CalculateMaxConnLimit(configParams, numTyphas, numNodes)
+		Expect(num).To(Equal(expectedNumber))
+		Expect(reason).To(Equal(expectedReason))
+	},
+	Entry("Single Typha", 1, 10, 101, "lone typha"),
+	Entry("Lower limit", 10, 10, 11, "configured lower limit"),
+	Entry("Fraction", 10, 500, 67, "fraction+20%"),
+	Entry("Upper limit", 2, 500, 101, "configured upper limit"),
+)
+
+var _ = Describe("Poll loop tests", func() {
+	var tickerC chan time.Time
+	var cxt context.Context
+	var cancelFn context.CancelFunc
+	var server *dummyServer
+	var k8sAPI *dummyK8sAPI
+
+	BeforeEach(func() {
+		tickerC = make(chan time.Time)
+		cxt, cancelFn = context.WithCancel(context.Background())
+		configParams := &config.Config{
+			K8sNamespace:             "ns",
+			K8sServiceName:           "svc",
+			K8sPortName:              "port",
+			MaxConnectionsUpperLimit: 101,
+			MaxConnectionsLowerLimit: 11,
+		}
+		k8sAPI = &dummyK8sAPI{
+			numTyphas: 5,
+			numNodes:  100,
+		}
+		server = &dummyServer{}
+		go func() {
+			defer GinkgoRecover()
+			PollK8sForConnectionLimit(cxt, configParams, tickerC, k8sAPI, server)
+		}()
+	})
+
+	AfterEach(func() {
+		cancelFn()
+	})
+
+	It("should emit on first tick", func() {
+		tickerC <- time.Now()
+		cancelFn()
+		Eventually(server.MaxConns).Should(Equal([]int{31}))
+	})
+	It("should squash dupes", func() {
+		tickerC <- time.Now()
+		tickerC <- time.Now()
+		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31}))
+	})
+	It("should responds to changes", func() {
+		tickerC <- time.Now()
+		k8sAPI.numNodes = 200
+		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31, 61}))
+	})
+	It("should increase limit to maximum on GetNumTyphas error", func() {
+		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31}))
+		k8sAPI.numTyphasErr = errors.New("bad typha!")
+		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31, 101}))
+	})
+	It("should increase limit to maximum on GetNumNodes error", func() {
+		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31}))
+		k8sAPI.numNodesErr = errors.New("bad nodes!")
+		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31, 101}))
+	})
+})
+
+type dummyServer struct {
+	L       sync.Mutex
+	targets []int
+}
+
+func (s *dummyServer) SetMaxConns(numConns int) {
+	s.L.Lock()
+	defer s.L.Unlock()
+	s.targets = append(s.targets, numConns)
+}
+
+func (s *dummyServer) MaxConns() []int {
+	s.L.Lock()
+	defer s.L.Unlock()
+	return s.targets
+}
+
+type dummyK8sAPI struct {
+	numTyphas    int
+	numTyphasErr error
+	numNodes     int
+	numNodesErr  error
+}
+
+func (d *dummyK8sAPI) GetNumTyphas(namespace, serviceName, portName string) (int, error) {
+	Expect(namespace).To(Equal("ns"))
+	Expect(serviceName).To(Equal("svc"))
+	Expect(portName).To(Equal("port"))
+	return d.numTyphas, d.numTyphasErr
+}
+func (d *dummyK8sAPI) GetNumNodes() (int, error) {
+	return d.numNodes, d.numNodesErr
+}

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -25,6 +25,8 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"math"
+
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/typha/pkg/buildinfo"
 	"github.com/projectcalico/typha/pkg/jitter"
@@ -41,6 +43,14 @@ var (
 	counterNumConnectionsAccepted = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "typha_connections_accepted",
 		Help: "Total number of connections accepted over time.",
+	})
+	counterNumConnectionsRejected = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "typha_connections_rejected",
+		Help: "Total number of connections rejected due to throttling.",
+	})
+	counterNumConnectionsDropped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "typha_connections_dropped",
+		Help: "Total number of connections dropped due to rebalancing.",
 	})
 	gaugeNumConnections = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "typha_connections_active",
@@ -77,6 +87,8 @@ var (
 
 func init() {
 	prometheus.MustRegister(counterNumConnectionsAccepted)
+	prometheus.MustRegister(counterNumConnectionsRejected)
+	prometheus.MustRegister(counterNumConnectionsDropped)
 	prometheus.MustRegister(gaugeNumConnections)
 	prometheus.MustRegister(summarySnapshotSendTime)
 	prometheus.MustRegister(summaryClientLatency)
@@ -91,6 +103,8 @@ const (
 	defaultMaxFallBehind        = 90 * time.Second
 	defaultBatchingAgeThreshold = 100 * time.Millisecond
 	defaultPingInterval         = 10 * time.Second
+	defaultDropInterval         = 1 * time.Second
+	defaultMaxConns             = math.MaxInt32
 )
 
 type Server struct {
@@ -99,8 +113,10 @@ type Server struct {
 	nextConnID uint64
 	maxConnsC  chan int
 
-	connIDToConnL sync.Mutex
-	connIDToConn  map[uint64]*connection
+	dropInterval     time.Duration
+	connTrackingLock sync.Mutex
+	maxConns         int
+	connIDToConn     map[uint64]*connection
 }
 
 type BreadcrumbProvider interface {
@@ -113,6 +129,8 @@ type Config struct {
 	MinBatchingAgeThreshold time.Duration
 	PingInterval            time.Duration
 	PongTimeout             time.Duration
+	DropInterval            time.Duration
+	MaxConns                int
 }
 
 func New(cache BreadcrumbProvider, config Config) *Server {
@@ -152,12 +170,27 @@ func New(cache BreadcrumbProvider, config Config) *Server {
 		}).Info("PongTimeout < PingInterval * 2; Defaulting PongTimeout.")
 		config.PongTimeout = defaultTimeout
 	}
+	if config.DropInterval <= 0 {
+		log.WithFields(log.Fields{
+			"value":   config.DropInterval,
+			"default": defaultDropInterval,
+		}).Info("Defaulting DropInterval.")
+		config.DropInterval = defaultDropInterval
+	}
+	if config.MaxConns <= 0 {
+		log.WithFields(log.Fields{
+			"value":   config.MaxConns,
+			"default": defaultMaxConns,
+		}).Info("Defaulting MaxConns.")
+		config.MaxConns = defaultMaxConns
+	}
 
 	return &Server{
-		config:    config,
-		cache:     cache,
-		maxConnsC: make(chan int),
-
+		config:       config,
+		cache:        cache,
+		maxConnsC:    make(chan int),
+		dropInterval: config.DropInterval,
+		maxConns:     config.MaxConns,
 		connIDToConn: map[uint64]*connection{},
 	}
 }
@@ -187,6 +220,14 @@ func (s *Server) serve(cxt context.Context) {
 			logCxt.WithError(err).Panic("Failed to accept connection")
 		}
 
+		if s.overConnLimit() {
+			logCxt.WithField("conn", conn.RemoteAddr()).Warn(
+				"Too many active connections, dropping incoming connection.")
+			counterNumConnectionsRejected.Inc()
+			conn.Close()
+			continue
+		}
+
 		connID := s.nextConnID
 		s.nextConnID++
 		logCxt.WithField("connID", connID).Info("New connection")
@@ -211,64 +252,75 @@ func (s *Server) serve(cxt context.Context) {
 			readC:   make(chan interface{}),
 		}
 
-		// Record the active connection so we can close it later if we need to.
-		s.connIDToConnL.Lock()
-		s.connIDToConn[connID] = connection
-		s.connIDToConnL.Unlock()
-		// Queue up the cleanup of our tracking map when the connection gets closed.
 		go func() {
-			<-connCxt.Done()
-			s.connIDToConnL.Lock()
-			delete(s.connIDToConn, connID)
-			s.connIDToConnL.Unlock()
+			// Track the connection's lifetime in connIDToConn so we can kill it later if needed.
+			s.recordConnection(connection)
+			defer s.discardConnection(connection)
+			// Defer to the connection to do the handling.
+			connection.handle()
 		}()
-		go connection.handle()
 	}
+}
+
+func (s *Server) overConnLimit() bool {
+	s.connTrackingLock.Lock()
+	defer s.connTrackingLock.Unlock()
+	return len(s.connIDToConn) >= s.maxConns
+}
+
+func (s *Server) recordConnection(conn *connection) {
+	s.connTrackingLock.Lock()
+	s.connIDToConn[conn.ID] = conn
+	s.connTrackingLock.Unlock()
+}
+
+func (s *Server) discardConnection(conn *connection) {
+	s.connTrackingLock.Lock()
+	delete(s.connIDToConn, conn.ID)
+	s.connTrackingLock.Unlock()
 }
 
 func (s *Server) governNumberOfConnections(cxt context.Context) {
 	logCxt := log.WithField("thread", "numConnsGov")
-	maxConns := <-s.maxConnsC
-	ticker := jitter.NewTicker(time.Second, 100*time.Millisecond)
+	maxConns := s.maxConns
+	ticker := jitter.NewTicker(s.dropInterval, s.dropInterval/10)
 	for {
 		select {
 		case newMax := <-s.maxConnsC:
 			if newMax == maxConns {
 				continue
 			}
-			s.connIDToConnL.Lock()
+			s.connTrackingLock.Lock()
 			currentNum := len(s.connIDToConn)
-			s.connIDToConnL.Unlock()
+			s.connTrackingLock.Unlock()
 			logCxt.WithFields(log.Fields{
 				"oldMax":     maxConns,
 				"newMax":     newMax,
 				"currentNum": currentNum,
 			}).Info("New target number of connections")
 			maxConns = newMax
+			s.connTrackingLock.Lock()
+			s.maxConns = maxConns
+			s.connTrackingLock.Unlock()
 		case <-ticker.C:
-			if maxConns < 100 {
-				log.Warn("Sanity check: max connections was <100, defaulting")
-				maxConns = 100
-			}
-			s.connIDToConnL.Lock()
+			s.connTrackingLock.Lock()
 			numConns := len(s.connIDToConn)
-			var cancelFn context.CancelFunc
 			if numConns > maxConns {
-				for _, conn := range s.connIDToConn {
+				for connID, conn := range s.connIDToConn {
 					logCxt.WithFields(log.Fields{
 						"max":     maxConns,
 						"current": numConns,
-						"connID":  conn.ID,
+						"connID":  connID,
 					}).Warn("Currently have too many connections, terminating one at random.")
-					cancelFn = conn.cancelCxt
+					conn.cancelCxt()
+					counterNumConnectionsDropped.Inc()
+					// Remove from the map now so that the connection count immediately drops;
+					// otherwise we might drop too many connections.
+					delete(s.connIDToConn, connID)
 					break
 				}
 			}
-			s.connIDToConnL.Unlock()
-			if cancelFn != nil {
-				// Drop locks before we invoke the cancel function, just to avoid any kind of hierarchy.
-				cancelFn()
-			}
+			s.connTrackingLock.Unlock()
 		case <-cxt.Done():
 			logCxt.Info("Context asked us to stop")
 			return


### PR DESCRIPTION
## Description
Monitor the k8s API to find the number of nodes and number of Typha instances.  Drop connections to rebalance if the load gets too skewed.

## Todos
- [x] Unit tests - covering the algorithm in this PR but we'll need a bunch of infrastructure to test the k8s API calls.
- [x] Integration tests (delete as appropriate) planned
- [ ] Update test manifests
- [ ] Documentation
