### PR TITLE
Add FV tests for Typha

### DIFF
--- a/cmd/typha-client/typha-client.go
+++ b/cmd/typha-client/typha-client.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/docopt/docopt-go"
 
+	"context"
+
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/typha/pkg/buildinfo"
 	"github.com/projectcalico/typha/pkg/config"
@@ -86,8 +88,10 @@ func main() {
 	callbacks := &syncerCallbacks{}
 	addr := arguments["--server"].(string)
 	client := syncclient.New(addr, buildinfo.GitVersion, "test-host", "some info", callbacks)
-	client.Start()
-	for {
-		time.Sleep(10 * time.Second)
+	err = client.Start(context.Background())
+	if err != nil {
+		log.WithError(err).Panic("Client failed")
 	}
+	client.Finished.Wait()
+	log.Panic("Client failed")
 }

--- a/fv-tests/doc.go
+++ b/fv-tests/doc.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fv_tests_test
-
-import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"testing"
-)
-
-import "github.com/projectcalico/libcalico-go/lib/testutils"
-
-func init() {
-	testutils.HookLogrusForGinkgo()
-}
-
-func TestFvTests(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "FV Tests Suite")
-}
+// fv_tests contains a suite of tests that test multiple packaged together.  In particular, we
+// start a real server and snapshot cache in-process and make loop-back connections to it.
+package fv_tests

--- a/fv-tests/fv_tests_suite_test.go
+++ b/fv-tests/fv_tests_suite_test.go
@@ -21,10 +21,14 @@ import (
 	"testing"
 )
 
-import "github.com/projectcalico/libcalico-go/lib/testutils"
+import (
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+	"github.com/projectcalico/typha/pkg/logutils"
+)
 
 func init() {
 	testutils.HookLogrusForGinkgo()
+	logutils.ConfigureEarlyLogging()
 }
 
 func TestFvTests(t *testing.T) {

--- a/fv-tests/fv_tests_suite_test.go
+++ b/fv-tests/fv_tests_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_tests_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+import "github.com/projectcalico/libcalico-go/lib/testutils"
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
+func TestFvTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FvTests Suite")
+}

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -307,12 +307,17 @@ var _ = Describe("With an in-process Server", func() {
 			}
 			server.SetMaxConns(40)
 			timeout := time.NewTimer(5 * time.Second)
+			oneSec := time.NewTimer(1 * time.Second)
 			numFinished := 0
 		loop:
 			for {
 				select {
 				case <-timeout.C:
 					break loop
+				case <-oneSec.C:
+					// After one second we should have dropped approximately 20 clients.
+					Expect(numFinished).To(BeNumerically(">", 10))
+					Expect(numFinished).To(BeNumerically("<", 30))
 				case c := <-finishedC:
 					numFinished += c
 				}

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fv_tests_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectcalico/typha/pkg/snapcache"
+	"github.com/projectcalico/typha/pkg/syncserver"
+)
+
+var _ = Describe("With an in-process Server", func() {
+	var snapCache *snapcache.Cache
+	var server *syncserver.Server
+	var cxt context.Context
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		snapCache = snapcache.New(snapcache.Config{
+			MaxBatchSize: 10,
+			// Reduce the wake up interval from the default to give us faster tear down.
+			WakeUpInterval: 50 * time.Millisecond,
+		})
+		server = syncserver.New(snapCache, syncserver.Config{
+			DropInterval: 100 * time.Millisecond,
+			Port:         syncserver.PortRandom,
+		})
+		cxt, cancel = context.WithCancel(context.Background())
+		snapCache.Start(cxt)
+		server.Start(cxt)
+	})
+
+	It("should choose a port", func() {
+		Expect(server.Port()).ToNot(BeZero())
+	})
+
+	AfterEach(func() {
+		cancel()
+		server.Finished.Wait()
+	})
+})

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -116,7 +116,7 @@ var _ = Describe("With an in-process Server", func() {
 		It("should pass through many KVs", func() {
 			expectedEndState := map[string]api.Update{}
 			cache.OnStatusUpdated(api.ResyncInProgress)
-			for i := 0; i < 100; i++ {
+			for i := 0; i < 1000; i++ {
 				update := api.Update{
 					KVPair: model.KVPair{
 						Key: model.GlobalConfigKey{

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -91,7 +91,6 @@ var _ = Describe("With an in-process Server", func() {
 		server       *syncserver.Server
 		serverCxt    context.Context
 		serverCancel context.CancelFunc
-		serverAddr   string
 	)
 
 	// Each client we create gets recorded here for cleanup.
@@ -158,8 +157,6 @@ var _ = Describe("With an in-process Server", func() {
 		cache.Start(cacheCxt)
 		serverCxt, serverCancel = context.WithCancel(context.Background())
 		server.Start(serverCxt)
-		serverAddr = fmt.Sprintf("127.0.0.1:%d", server.Port())
-
 	})
 
 	AfterEach(func() {

--- a/pkg/calc/validation_filter.go
+++ b/pkg/calc/validation_filter.go
@@ -67,7 +67,14 @@ func (v *ValidationFilter) OnUpdates(updates []api.Update) {
 				// about the host metadata anyway.  Extract the Host IP.
 				update.Key = model.HostIPKey{Hostname: k.Hostname}
 				if update.Value != nil {
-					update.Value = update.Value.(*model.Node).FelixIPv4
+					node, ok := update.Value.(*model.Node)
+					if ok {
+						update.Value = node.FelixIPv4
+					} else {
+						logCxt.WithField("value", update.Value).Warn(
+							"NodeKey value wasn't a *Node; treating as missing")
+						update.Value = nil
+					}
 				}
 			}
 

--- a/pkg/snapcache/cache.go
+++ b/pkg/snapcache/cache.go
@@ -195,6 +195,7 @@ func (c *Cache) Start(ctx context.Context) {
 }
 
 func (c *Cache) loop(ctx context.Context) {
+	defer c.breadcrumbCond.Broadcast()
 	for {
 		// First, block, waiting for updates and batch them up in our pendingXXX fields.
 		// This will opportunistically slurp up a limited number of pending updates.

--- a/pkg/snapcache/cache.go
+++ b/pkg/snapcache/cache.go
@@ -195,7 +195,6 @@ func (c *Cache) Start(ctx context.Context) {
 }
 
 func (c *Cache) loop(ctx context.Context) {
-	defer c.breadcrumbCond.Broadcast()
 	for {
 		// First, block, waiting for updates and batch them up in our pendingXXX fields.
 		// This will opportunistically slurp up a limited number of pending updates.

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -106,8 +106,9 @@ func (s *SyncerClient) connect(cxt context.Context) error {
 }
 
 func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
+	defer s.Finished.Done()
 	defer cancelFn()
-	s.Finished.Done()
+
 	logCxt := log.WithField("address", s.addr)
 	logCxt.Info("Started Typha client main loop")
 

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -198,7 +198,7 @@ func New(cache BreadcrumbProvider, config Config) *Server {
 		log.Info("Choosing random port")
 		config.Port = 0
 	}
-
+	log.WithField("config", config).Info("Creating server")
 	return &Server{
 		config:       config,
 		cache:        cache,

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -245,6 +245,7 @@ func (s *Server) serve(cxt context.Context) {
 		s.Finished.Done()
 	}()
 	s.chosenPort = l.Addr().(*net.TCPAddr).Port
+	logCxt = log.WithField("port", s.chosenPort)
 	close(s.listeningC)
 	for {
 		logCxt.Debug("About to accept connection")

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -448,8 +448,12 @@ func (h *connection) handle(finishedWG *sync.WaitGroup) (err error) {
 				return errors.New("Unknown message type")
 			}
 		case <-pongTicker.C:
-			if time.Since(lastPongReceived) > h.config.PongTimeout {
-				h.logCxt.Info("Too long since last pong from client, disconnecting")
+			since := time.Since(lastPongReceived)
+			if since > h.config.PongTimeout {
+				h.logCxt.WithFields(log.Fields{
+					"pongTimeout":       h.config.PongTimeout,
+					"timeSinceLastPong": since,
+				}).Info("Too long since last pong from client, disconnecting")
 				return errors.New("No pong received from client")
 			}
 		case <-h.cxt.Done():

--- a/pkg/syncserver/syncserver_suite_test.go
+++ b/pkg/syncserver/syncserver_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncserver_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
+func TestSyncserver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Syncserver Suite")
+}

--- a/pkg/syncserver/syncserver_test.go
+++ b/pkg/syncserver/syncserver_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncserver_test
+
+import (
+	. "github.com/projectcalico/typha/pkg/syncserver"
+
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("With zero config", func() {
+	var config Config
+	BeforeEach(func() {
+		config = Config{}
+	})
+	It("it should apply correct defaults", func() {
+		config.ApplyDefaults()
+		Expect(config).To(Equal(Config{
+			MaxMessageSize:          100,
+			MaxFallBehind:           90 * time.Second,
+			MinBatchingAgeThreshold: 100 * time.Millisecond,
+			PingInterval:            10 * time.Second,
+			PongTimeout:             60 * time.Second,
+			DropInterval:            time.Second,
+			MaxConns:                math.MaxInt32,
+			Port:                    5473,
+		}))
+	})
+	It("should convert random port to 0", func() {
+		config.Port = PortRandom
+		config.ApplyDefaults()
+		Expect(config.ListenPort()).To(Equal(0))
+	})
+	It("should convert 0 port to default", func() {
+		config.ApplyDefaults()
+		Expect(config.ListenPort()).To(Equal(5473))
+	})
+})

--- a/utils/run-coverage
+++ b/utils/run-coverage
@@ -21,7 +21,7 @@ test_pkgs=$(go list -f '{{ if .TestGoFiles | or .XTestGoFiles }}{{ .ImportPath }
 test ! -z "$test_pkgs"
 echo "Packages with tests: $test_pkgs"
 
-ginkgo -cover -covermode=count -coverpkg=${go_dirs} -r
+ginkgo -cover -covermode=count -coverpkg=${go_dirs} -r -p
 gocovmerge $(find . -name '*.coverprofile') > combined.coverprofile
 
 # Print the coverage.  We use sed to remove the verbose prefix and trim down


### PR DESCRIPTION
## Description
Add FV tests for Typha.  These start the bulk of a Typha server and run those components together.  Allows for testing the server layer, which is tricky to test by mocking.

## Todos
- [x] Documentation