### PR TITLE
Apply TLS to Felix-Typha connections

### DIFF
--- a/pkg/config/config_params_test.go
+++ b/pkg/config/config_params_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 )
 
 var _ = DescribeTable("Config parsing",
@@ -76,4 +77,47 @@ var _ = DescribeTable("Config parsing",
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
 	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),
 	Entry("PrometheusProcessMetricsEnabled", "PrometheusProcessMetricsEnabled", "false", false),
+)
+
+var _ = DescribeTable("Config validation",
+	func(settings map[string]string, ok bool) {
+		cfg := New()
+		cfg.UpdateFrom(settings, ConfigFile)
+		err := cfg.Validate()
+		log.WithError(err).Info("Validation result")
+		if !ok {
+			Expect(err).To(HaveOccurred())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	},
+
+	Entry("no settings", map[string]string{}, true),
+	Entry("just one TLS setting", map[string]string{
+		"ServerKeyFile": "/usr",
+	}, false),
+	Entry("TLS certs and key but no CN or URI SAN", map[string]string{
+		"ServerKeyFile":  "/usr",
+		"ServerCertFile": "/usr",
+		"CAFile":         "/usr",
+	}, false),
+	Entry("TLS certs and key and CN but no URI SAN", map[string]string{
+		"ServerKeyFile":  "/usr",
+		"ServerCertFile": "/usr",
+		"CAFile":         "/usr",
+		"ClientCN":       "typha-peer",
+	}, true),
+	Entry("TLS certs and key and URI SAN but no CN", map[string]string{
+		"ServerKeyFile":  "/usr",
+		"ServerCertFile": "/usr",
+		"CAFile":         "/usr",
+		"ClientURISAN":   "spiffe://k8s.example.com/typha-peer",
+	}, true),
+	Entry("all Felix-Typha TLS params", map[string]string{
+		"ServerKeyFile":  "/usr",
+		"ServerCertFile": "/usr",
+		"CAFile":         "/usr",
+		"ClientCN":       "typha-peer",
+		"ClientURISAN":   "spiffe://k8s.example.com/typha-peer",
+	}, true),
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -331,6 +331,11 @@ func (t *TyphaDaemon) CreateServer() {
 			MaxConns:                t.ConfigParams.MaxConnectionsUpperLimit,
 			Port:                    t.ConfigParams.ServerPort,
 			HealthAggregator:        t.healthAggregator,
+			KeyFile:                 t.ConfigParams.ServerKeyFile,
+			CertFile:                t.ConfigParams.ServerCertFile,
+			CAFile:                  t.ConfigParams.CAFile,
+			ClientCN:                t.ConfigParams.ClientCN,
+			ClientURISAN:            t.ConfigParams.ClientURISAN,
 		},
 	)
 }

--- a/pkg/tlsutils/tlsutils.go
+++ b/pkg/tlsutils/tlsutils.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutils
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/url"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Common code for verifying whether a peer certificate has a required Common Name and/or a required
+// URI SAN.
+func CertificateVerifier(logCxt *log.Entry, roots *x509.CertPool, requiredCN, requiredURISAN string) func([][]byte, [][]*x509.Certificate) error {
+	log.WithFields(log.Fields{
+		"roots":          roots,
+		"requiredCN":     requiredCN,
+		"requiredURISAN": requiredURISAN,
+	}).Info("Make certificate verifier")
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(verifiedChains) == 0 {
+			// We haven't yet verified that the peer certificate is signed by a trusted
+			// CA.  (Because the client-side TLS config sets InsecureSkipVerify true, in
+			// order to skip verifying against the server hostname or IP address.)  Do
+			// certificate chain verification now.
+			logCxt.Info("Verify certificate chain signing")
+			certs := make([]*x509.Certificate, len(rawCerts))
+			for i, asn1Data := range rawCerts {
+				cert, err := x509.ParseCertificate(asn1Data)
+				if err != nil {
+					return errors.New("Failed to parse certificate: " + err.Error())
+				}
+				certs[i] = cert
+			}
+
+			opts := x509.VerifyOptions{
+				Roots:         roots,
+				Intermediates: x509.NewCertPool(),
+			}
+
+			for i, cert := range certs {
+				if i == 0 {
+					continue
+				}
+				opts.Intermediates.AddCert(cert)
+			}
+			var err error
+			verifiedChains, err = certs[0].Verify(opts)
+			if err != nil {
+				return err
+			}
+		}
+
+		// When successful, Verify returns one or more chains, with the leaf certificate
+		// being the first in each chain.
+		leafCert := verifiedChains[0][0]
+
+		requiredCNFound := false
+		if requiredCN != "" {
+			requiredCNFound = (leafCert.Subject.CommonName == requiredCN)
+		}
+
+		requiredURIFound := false
+		if requiredURISAN != "" {
+			for _, uri := range leafCert.URIs {
+				logCxt.WithField("uri", uri).Info("Checking URI")
+				if uri.String() == requiredURISAN {
+					requiredURIFound = true
+					break
+				}
+			}
+		}
+
+		if requiredCN != "" && requiredURISAN != "" {
+			if !(requiredCNFound || requiredURIFound) {
+				return errors.New("Peer certificate does not have required CN or URI SAN")
+			}
+		} else if requiredCN != "" {
+			if !requiredCNFound {
+				return errors.New("Peer certificate does not have required CN")
+			}
+		} else if requiredURISAN != "" {
+			if !requiredURIFound {
+				return errors.New("Peer certificate does not have required URI SAN")
+			}
+		}
+
+		// Reaching here means that the certificate was valid and had required CN and/or URI
+		// SAN.
+		return nil
+	}
+}
+
+// The following certificate generators panic if they hit any error.  This is a bit poor, but OK in
+// practice because they are only used by test code.
+func PanicIfErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+var serialNumber int = 0
+
+func MakeCACert(name string) (*x509.Certificate, *rsa.PrivateKey) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	PanicIfErr(err)
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(24 * time.Hour)
+	serialNumber++
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(int64(serialNumber)),
+		Subject: pkix.Name{
+			Organization: []string{name},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	PanicIfErr(err)
+	caCert, err := x509.ParseCertificate(derBytes)
+	PanicIfErr(err)
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(caCert)
+	_, err = caCert.Verify(x509.VerifyOptions{Roots: rootPool})
+	PanicIfErr(err)
+	return caCert, key
+}
+
+func MakePeerCert(cn, uriSAN string, extKeyUsage x509.ExtKeyUsage, caCert *x509.Certificate, caKey *rsa.PrivateKey) ([]byte, *rsa.PrivateKey) {
+	log.WithFields(log.Fields{
+		"cn":          cn,
+		"uriSAN":      uriSAN,
+		"extKeyUsage": extKeyUsage,
+	}).Info("Make peer cert")
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	PanicIfErr(err)
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(24 * time.Hour)
+	serialNumber++
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(int64(serialNumber)),
+		Subject: pkix.Name{
+			Organization: []string{"Widgits"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{extKeyUsage},
+		BasicConstraintsValid: true,
+	}
+
+	if cn != "" {
+		template.Subject.CommonName = cn
+	}
+	if uriSAN != "" {
+		uri, err := url.Parse(uriSAN)
+		PanicIfErr(err)
+		template.URIs = []*url.URL{uri}
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, caCert, &key.PublicKey, caKey)
+	PanicIfErr(err)
+	if caCert != nil {
+		log.Info("Verifying peer certificate")
+		peerCert, err := x509.ParseCertificate(derBytes)
+		PanicIfErr(err)
+		rootPool := x509.NewCertPool()
+		rootPool.AddCert(caCert)
+		_, err = peerCert.Verify(x509.VerifyOptions{
+			Roots:     rootPool,
+			KeyUsages: []x509.ExtKeyUsage{extKeyUsage},
+		})
+		PanicIfErr(err)
+	}
+	return derBytes, key
+}
+
+func WriteCert(data []byte, fileName string) {
+	certOut, err := os.Create(fileName)
+	PanicIfErr(err)
+	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: data})
+	PanicIfErr(err)
+	err = certOut.Close()
+	PanicIfErr(err)
+	log.Printf("written %v", fileName)
+}
+
+func WriteKey(key *rsa.PrivateKey, fileName string) {
+	keyOut, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	PanicIfErr(err)
+	err = pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	PanicIfErr(err)
+	err = keyOut.Close()
+	PanicIfErr(err)
+	log.Printf("written %v", fileName)
+}

--- a/pkg/tlsutils/tlsutils_suite_test.go
+++ b/pkg/tlsutils/tlsutils_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestTLSUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TLS utils Suite")
+}

--- a/pkg/tlsutils/tlsutils_test.go
+++ b/pkg/tlsutils/tlsutils_test.go
@@ -1,0 +1,225 @@
+// Copyright (c) 2018 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutils_test
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/projectcalico/typha/pkg/tlsutils"
+)
+
+const (
+	goodCN     = "typha-peer"
+	badCN      = "impostor"
+	goodURISAN = "spiffe://k8s.example.com/typha-peer"
+	badURISAN  = "spiffe://k8s.example.com/impostor"
+)
+
+type certConfig struct {
+	Signature string
+	CN        string
+	URISAN    string
+}
+
+type typhaConfig struct {
+	CAs    string
+	CN     string
+	URISAN string
+}
+
+func genTestCases() []TableEntry {
+	// Prepare certificate cases: all possible combinations of whether and how it's signed, what
+	// CN it has, and what URI SAN it has.
+	signatureConfigs := []string{
+		"SignedCA1",
+		"SignedCA2",
+		"SignedByUntrusted",
+	}
+	cnConfigs := []string{
+		"", // No CN.
+		goodCN,
+		badCN,
+	}
+	uriSANConfigs := []string{
+		"", // No URI SAN.
+		goodURISAN,
+		badURISAN,
+	}
+	var certConfigs []*certConfig
+	for _, signature := range signatureConfigs {
+		for _, cn := range cnConfigs {
+			for _, uri := range uriSANConfigs {
+				certConfigs = append(certConfigs, &certConfig{
+					Signature: signature,
+					CN:        cn,
+					URISAN:    uri,
+				})
+			}
+		}
+	}
+
+	// Prepare Typha config cases: all possible combinations of CA cert(s), required CN and
+	// required SAN.
+	caConfigs := []string{
+		"NoTrustedCAs",
+		"TrustCA1Only",
+		"TrustCA2Only",
+		"TrustCA1AndCA2",
+	}
+	cnConfigs = []string{
+		"", // No CN.
+		goodCN,
+	}
+	uriSANConfigs = []string{
+		"", // No URI SAN.
+		goodURISAN,
+	}
+	var typhaConfigs []*typhaConfig
+	for _, ca := range caConfigs {
+		for _, cn := range cnConfigs {
+			for _, uri := range uriSANConfigs {
+				typhaConfigs = append(typhaConfigs, &typhaConfig{
+					CAs:    ca,
+					CN:     cn,
+					URISAN: uri,
+				})
+			}
+		}
+	}
+
+	// Prepare an Entry for each combination of cert config and Typha config.
+	var entries []TableEntry
+	for _, certConfig := range certConfigs {
+		peerCertBytes := makePeerCert(certConfig)
+		for _, typhaConfig := range typhaConfigs {
+			entries = append(entries, Entry(
+				fmt.Sprintf("%#v %#v", certConfig, typhaConfig),
+				peerCertBytes,
+				typhaConfig,
+				errChecker(certConfig, typhaConfig),
+			))
+		}
+	}
+	return entries
+}
+
+var (
+	certCA1, keyCA1                 = tlsutils.MakeCACert("CA1")
+	certCA2, keyCA2                 = tlsutils.MakeCACert("CA2")
+	certCAUntrusted, keyCAUntrusted = tlsutils.MakeCACert("CAUntrusted")
+)
+
+func expectOK(actualError error) {
+	Expect(actualError).NotTo(HaveOccurred())
+}
+
+func expectUntrustedCAError(actualError error) {
+	Expect(actualError).To(BeAssignableToTypeOf(x509.UnknownAuthorityError{}))
+}
+
+func expectErrorMessage(errorMessage string) func(error) {
+	return func(actualError error) {
+		Expect(actualError).To(MatchError(errorMessage))
+	}
+}
+
+func errChecker(certConfig *certConfig, typhaConfig *typhaConfig) func(error) {
+	// Possible errors based on certificate signature.
+	switch certConfig.Signature {
+	case "SignedCA1":
+		if typhaConfig.CAs != "TrustCA1Only" && typhaConfig.CAs != "TrustCA1AndCA2" {
+			return expectUntrustedCAError
+		}
+	case "SignedCA2":
+		if typhaConfig.CAs != "TrustCA2Only" && typhaConfig.CAs != "TrustCA1AndCA2" {
+			return expectUntrustedCAError
+		}
+	case "SignedByUntrusted":
+		return expectUntrustedCAError
+	}
+
+	// Possible errors based on certificate content.
+	if typhaConfig.CN != "" && certConfig.CN == typhaConfig.CN {
+		// Good.
+		return expectOK
+	}
+	if typhaConfig.URISAN != "" && certConfig.URISAN == typhaConfig.URISAN {
+		// Good.
+		return expectOK
+	}
+	if typhaConfig.CN != "" && typhaConfig.URISAN != "" {
+		// Required CN and URISAN both specified.
+		return expectErrorMessage("Peer certificate does not have required CN or URI SAN")
+	} else if typhaConfig.CN != "" {
+		return expectErrorMessage("Peer certificate does not have required CN")
+	} else if typhaConfig.URISAN != "" {
+		return expectErrorMessage("Peer certificate does not have required URI SAN")
+	}
+	return expectOK
+}
+
+var _ = DescribeTable("CertificateVerifier",
+	func(peerCertBytes []byte, typhaConfig *typhaConfig, errChecker func(err error)) {
+		roots := x509.NewCertPool()
+		switch typhaConfig.CAs {
+		case "NoTrustedCAs":
+			// No root certs.
+		case "TrustCA1Only":
+			roots.AddCert(certCA1)
+		case "TrustCA2Only":
+			roots.AddCert(certCA2)
+		case "TrustCA1AndCA2":
+			roots.AddCert(certCA1)
+			roots.AddCert(certCA2)
+		}
+		verifier := tlsutils.CertificateVerifier(
+			log.WithFields(log.Fields{
+				"typhaConfig": typhaConfig,
+			}),
+			roots,
+			typhaConfig.CN,
+			typhaConfig.URISAN,
+		)
+		err := verifier([][]byte{peerCertBytes}, nil)
+		errChecker(err)
+	},
+	genTestCases()...)
+
+func makePeerCert(cfg *certConfig) []byte {
+	log.WithField("cfg", cfg).Info("Make peer cert")
+	var (
+		caCert *x509.Certificate
+		caKey  *rsa.PrivateKey
+	)
+	switch cfg.Signature {
+	case "SignedCA1":
+		caCert = certCA1
+		caKey = keyCA1
+	case "SignedCA2":
+		caCert = certCA2
+		caKey = keyCA2
+	case "SignedByUntrusted":
+		caCert = certCAUntrusted
+		caKey = keyCAUntrusted
+	}
+	certBytes, _ := tlsutils.MakePeerCert(cfg.CN, cfg.URISAN, x509.ExtKeyUsageServerAuth, caCert, caKey)
+	return certBytes
+}


### PR DESCRIPTION
## Description
Using TLS to encrypt and authenticate the connections between Felix and Typha.

## Todos
- [ ] Fix up existing unit tests that use 'raw' connections instead of syncclient
- [ ] Additional unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan
- [ ] Documentation
