### PR TITLE
Pin go-datastructures library to one with Ctrie traverse fix.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: a596e45b0d5327504869aa74af31f14fb626ca028f243ece7d506c10f45cb78c
-updated: 2017-06-12T13:35:54.137659275Z
+hash: d5a5e99f1da2f3be24e7ba203a0a65d471f3faaaa146ce336e19cc6e243c2118
+updated: 2017-07-03T16:55:32.290366582Z
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
-  version: 66722b1ada68fcd5227db853ee92003169a975c8
+  version: 61fc123e7a8b14a0a258aa3f5c4159861b1ec2e7
   subpackages:
   - client
   - pkg/pathutil
@@ -50,14 +50,14 @@ imports:
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
-  version: 909568be09de550ed094403c2bf8a261b5bb730a
+  version: 100ba4e885062801d56799d78530b73b178a78f3
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
+  version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
   subpackages:
   - proto
 - name: github.com/google/gofuzz
@@ -83,7 +83,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/mipearson/rfw
-  version: b66ec87bd85055de3f749a8640e9e4c8053052e4
+  version: 6f0a6f3266ba1058df9ef0c94cda1cecd2e62852
 - name: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9d9
   subpackages:
@@ -175,7 +175,8 @@ imports:
   subpackages:
   - codec
 - name: github.com/Workiva/go-datastructures
-  version: 01ff43b05e5593e6e41f5988797126402611e2d7
+  version: 35e2d1cf2316766f1ab63d8260c173ccb21a4d85
+  repo: https://github.com/fasaxc/go-datastructures.git
   subpackages:
   - list
   - trie/ctrie
@@ -193,7 +194,7 @@ imports:
   - idna/
   - lex/httplex
 - name: golang.org/x/sys
-  version: 0b25a408a50076fbbcae6b7ac0ea5fbb0b085e79
+  version: 0e0164865330d5cf1c00247be08330bf96e2f87c
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,7 +40,8 @@ import:
 - package: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9
 - package: github.com/Workiva/go-datastructures
-  version: ^1.0.36
+  repo: https://github.com/fasaxc/go-datastructures.git
+  version: fix-ctrie-traverse
   subpackages:
   - trie/ctrie
 - package: golang.org/x/text
@@ -53,6 +54,8 @@ import:
   version: 4a3ab2f5be5177366f8206fd79ce55ca80e417fa
 - package: k8s.io/apimachinery
   version: b317fa7ec8e0e7d1f77ac63bf8c3ec7b29a2a215
+- package: github.com/gogo/protobuf
+  version: ^0.3.0
 testImport:
 - package: github.com/onsi/gomega
   version: 9b8c753e8dfb382618ba8fa19b4197b5dcb0434c


### PR DESCRIPTION
Fix that Felix instances that connected to Typha after some KV churn could be sent a snapshot with missing KVs.

Fixes #28.

## Description
The Ctrie datastructure we use had a bug:

If you created two keys, and they ended up in the same “internal node”, *and* it wasn’t the root internal node, *and* there were exactly two items in that node, *and* you deleted one, _then_ the internal node got converted to an optimised “entombed node” and entombed nodes were being skipped when iterating (but not when doing a lookup)

This PR pulls in the fix.

## Todos
- [x] Unit tests (full coverage in the upstream code)
