### PR TITLE
Advance libcalico-go pin to pick up pre-DNAT policy support

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9350592c048d75bd62c29eeab377284ccb241452b882efc544f635dd490f6e74
-updated: 2017-07-17T12:11:01.484302382Z
+hash: 1847cdf106df6e8085d241e5910354da8346074adbb0dda7033ad4708701a92e
+updated: 2017-07-19T10:15:13.551306815Z
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -114,7 +114,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 565f839a3bf08650d787337a562e4c0aa3d2d9ce
+  version: 639aa7b2d33b94419143a2e6987d2d77aa395f2f
   subpackages:
   - lib
   - lib/api
@@ -194,7 +194,7 @@ imports:
   - idna/
   - lex/httplex
 - name: golang.org/x/sys
-  version: 4cd6d1a821c7175768725b55ca82f14683a29ea4
+  version: cd2c276457edda6df7fb04895d3fd6a6add42926
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 565f839a3bf08650d787337a562e4c0aa3d2d9ce
+  version: 639aa7b2d33b94419143a2e6987d2d77aa395f2f
   subpackages:
   - lib
 - package: github.com/Sirupsen/logrus


### PR DESCRIPTION
## Description
Typha part of https://github.com/projectcalico/calico/issues/823 - see there for more details.