### PR TITLE
Update the import for logrus to use the updated username

### DIFF
--- a/check-licenses/check_licenses.go
+++ b/check-licenses/check_licenses.go
@@ -17,7 +17,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"bufio"
 	"regexp"

--- a/cmd/typha-client/typha-client.go
+++ b/cmd/typha-client/typha-client.go
@@ -17,7 +17,7 @@ package main
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"math/rand"
 	"runtime"

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -26,8 +26,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dc862b89e90c2d3fc169a2ccec9b66e4427734157a038165cac29b247eb8d48d
-updated: 2017-07-21T13:49:59.322964923-07:00
+hash: c2ad62d3ebec8994054fa8bb675e43934791f5da8291e21c0370958dfa862ef8
+updated: 2017-07-31T15:18:41.588321487-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -114,7 +114,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: e1ab5e5bf4a57ea6fa71bf4a7712af27b824a005
+  version: 93f9e49214a678551648eb9c28ce57bc286a3169
   subpackages:
   - lib
   - lib/api
@@ -168,7 +168,7 @@ imports:
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
@@ -177,7 +177,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/Workiva/go-datastructures
-  version: d2b2290a45db4d6aa0e1b0beb0045a9dc7094aff
+  version: b4ec1df61a85b06ecd47d331e081250781675c9c
   repo: https://github.com/fasaxc/go-datastructures.git
   subpackages:
   - list
@@ -228,7 +228,7 @@ imports:
   - unicode/norm
   - width
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tchap/go-patricia.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,10 +27,10 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: ^v1.5.0
+  version: 93f9e49214a678551648eb9c28ce57bc286a3169
   subpackages:
   - lib
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: ^0.11.5
 - package: github.com/kardianos/osext
 - package: github.com/mipearson/rfw

--- a/pkg/calc/async_decoupler.go
+++ b/pkg/calc/async_decoupler.go
@@ -17,7 +17,7 @@ package calc
 import (
 	"context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 )

--- a/pkg/calc/validation_filter.go
+++ b/pkg/calc/validation_filter.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"reflect"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"time"
 

--- a/pkg/config/env_var_loader.go
+++ b/pkg/config/env_var_loader.go
@@ -17,7 +17,7 @@ package config
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // LoadConfigFromEnvironment extracts raw config parameters (identified by

--- a/pkg/config/file_loader.go
+++ b/pkg/config/file_loader.go
@@ -18,8 +18,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/go-ini/ini"
+	log "github.com/sirupsen/logrus"
 )
 
 func LoadConfigFile(filename string) (map[string]string, error) {

--- a/pkg/config/param_types.go
+++ b/pkg/config/param_types.go
@@ -28,8 +28,8 @@ import (
 
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/kardianos/osext"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -28,10 +28,10 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	docopt "github.com/docopt/docopt-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend"

--- a/pkg/jitter/jittered_ticker.go
+++ b/pkg/jitter/jittered_ticker.go
@@ -18,7 +18,7 @@ import (
 	"math/rand"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Ticker tries to emit events on channel C at minDuration intervals plus up to maxJitter.

--- a/pkg/jitter/jittered_ticker_test.go
+++ b/pkg/jitter/jittered_ticker_test.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Real 20ms + 10ms Ticker", func() {

--- a/pkg/k8s/lookup.go
+++ b/pkg/k8s/lookup.go
@@ -15,7 +15,7 @@
 package k8s
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/pkg/k8s/rebalance.go
+++ b/pkg/k8s/rebalance.go
@@ -15,7 +15,7 @@
 package k8s
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"context"
 	"time"

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/mipearson/rfw"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/typha/pkg/config"
 )

--- a/pkg/logutils/logutils_test.go
+++ b/pkg/logutils/logutils_test.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 
 	"sync"
 

--- a/pkg/snapcache/cache.go
+++ b/pkg/snapcache/cache.go
@@ -21,9 +21,9 @@ import (
 	"time"
 	"unsafe"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/Workiva/go-datastructures/trie/ctrie"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/health"

--- a/pkg/snapcache/cache_test.go
+++ b/pkg/snapcache/cache_test.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/typha/pkg/syncproto"

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	"math"
 


### PR DESCRIPTION
## Description
Updating the logrus import to use the new updated user name (which is lowercased). This will prevent import errors with vendoring going forward.

Requires projectcalico/libcalico-go#484

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests Not needed
- [x] Documentation
- [x] Backport
- [x] Release note

## Release Note
```release-note
None required
```
