### PR TITLE
Adding support for ppc64le builds.

### DIFF
--- a/docker-image/Dockerfile-ppc64le
+++ b/docker-image/Dockerfile-ppc64le
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM ppc64le/alpine:3.6
 MAINTAINER Shaun Crampton <shaun@tigera.io>
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
@@ -10,9 +10,9 @@ ADD typha.cfg /etc/calico/typha.cfg
 # Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
 # to more easily extract the build artefacts from the container.
 RUN mkdir /code
-ADD bin/calico-typha-amd64 /code
+ADD bin/calico-typha-ppc64le /code
 WORKDIR /code
-RUN ln -s /code/calico-typha-amd64 /usr/bin/calico-typha
+RUN ln -s /code/calico-typha-ppc64le /usr/bin/calico-typha
 
 # Run Typha by default
 CMD ["calico-typha"]


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

Adding support for ppc64le build.

The build architecture is select by setting the ARCH environment variable.
For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
When ARCH is undefined builds defaults to amd64.

Note:  
calico-typha and typha-client are now crated as calico-typha-$(ARCH) and typha-client-$(ARCH).   When the docker images is created typha-client is linked to calico-typha-$(ARCH) in the container.  This prevents accidental picking up a stale binary when doing multi arch builds.  Thanks to Casey for this idea.

However,  I could not find a user of typha-client so it is left as typha-client-$(ARCH) in the build directory. 
