### PR TITLE
Don't let datastore connectivity block liveness reporting

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -201,17 +201,28 @@ configRetry:
 	t.BuildInfoLogCxt.WithField("config", configParams).Info(
 		"Successfully loaded configuration.")
 
-	// Make sure the datastore is initialized, otherwise the Syncer may spin, looking for
-	// non-existent resources.
-	for {
-		err := t.DatastoreClient.EnsureInitialized()
-		if err != nil {
-			log.WithError(err).Error("Failed to ensure datastore was initialized")
-			time.Sleep(1 * time.Second)
-			continue
+	// Ensure that, as soon as we are able to connect to the datastore at all, it is
+	// initialized; otherwise the Syncer may spin, looking for non-existent resources.
+	//
+	// But, do this in a background goroutine so as not to block Typha overall; specifically, we
+	// want Typha to report itself as live even if there is an initial problem connecting to the
+	// datastore.
+	//
+	// Note that Typha should cope with intermittent loss of connectivity to the datastore,
+	// because - apart from this EnsureInitialized call here - all of its interaction with the
+	// datastore is via a Syncer, and the Syncer is designed to handle HTTP request errors by
+	// reconnecting.
+	go func() {
+		for {
+			err := t.DatastoreClient.EnsureInitialized()
+			if err != nil {
+				log.WithError(err).Error("Failed to ensure datastore was initialized")
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			break
 		}
-		break
-	}
+	}()
 	t.ConfigParams = configParams
 }
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -15,7 +15,10 @@
 package daemon_test
 
 import (
+	"errors"
+	"strconv"
 	"sync"
+	"time"
 
 	. "github.com/projectcalico/typha/pkg/daemon"
 
@@ -96,6 +99,8 @@ var _ = Describe("Daemon", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			d.ParseCommandLineArgs([]string{"-c", configFile.Name()})
+		})
+		JustBeforeEach(func() {
 			d.LoadConfiguration()
 			Expect(loggingConfigured).To(BeTrue())
 		})
@@ -104,12 +109,46 @@ var _ = Describe("Daemon", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		const (
+			downSecs  = 2
+			checkTime = "2s"
+		)
+		downSecsStr := strconv.Itoa(downSecs)
+
 		It("should load the configuration and connect to the datastore", func() {
-			Eventually(func() bool {
+			Eventually(backend.getNumInitCalls).Should(Equal(1))
+			Consistently(backend.getNumInitCalls, checkTime, "1s").Should(Equal(1))
+		})
+
+		Describe("with datastore down for "+downSecsStr+"s", func() {
+			BeforeEach(func() {
 				backend.mutex.Lock()
 				defer backend.mutex.Unlock()
-				return backend.initCalled
-			}).Should(BeTrue())
+				backend.failInit = true
+			})
+			JustBeforeEach(func() {
+				time.Sleep(downSecs * time.Second)
+			})
+
+			It("should try >="+downSecsStr+" times to initialize the datastore", func() {
+				Eventually(backend.getNumInitCalls).Should(BeNumerically(">=", downSecs))
+			})
+
+			Describe("with datastore now available", func() {
+				var numFailedInitCalls int
+
+				JustBeforeEach(func() {
+					backend.mutex.Lock()
+					defer backend.mutex.Unlock()
+					backend.failInit = false
+					numFailedInitCalls = backend.initCalled
+				})
+
+				It("should initialize the datastore", func() {
+					Eventually(backend.getNumInitCalls).Should(Equal(numFailedInitCalls + 1))
+					Consistently(backend.getNumInitCalls, checkTime, "1s").Should(Equal(numFailedInitCalls + 1))
+				})
+			})
 		})
 
 		It("should create the server components", func() {
@@ -163,7 +202,8 @@ var _ = Describe("Daemon", func() {
 type mockBackend struct {
 	mutex        sync.Mutex
 	syncerCalled bool
-	initCalled   bool
+	initCalled   int
+	failInit     bool
 }
 
 func (b *mockBackend) Syncer(callbacks bapi.SyncerCallbacks) bapi.Syncer {
@@ -176,8 +216,17 @@ func (b *mockBackend) Syncer(callbacks bapi.SyncerCallbacks) bapi.Syncer {
 func (b *mockBackend) EnsureInitialized() error {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-	b.initCalled = true
+	b.initCalled++
+	if b.failInit {
+		return errors.New("Failure simulated by test code")
+	}
 	return nil
+}
+
+func (b *mockBackend) getNumInitCalls() int {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return b.initCalled
 }
 
 type dummySyncer struct {


### PR DESCRIPTION
## Description
The spec for Typha liveness and readiness reporting is that Typha should report itself as:
- live, so long as its Felix-serving loop has not died or hung
- ready, so long as it is connected to its datastore, and is not doing a resync (either the initial resync, or a subsequent one).

However, if the datastore is unavailable (for some reason) when Typha is started, Typha does not report itself as live because it gets stuck trying to ensure that the datastore is initialized.  This PR fixes that problem.

There is already an FV test for this at https://github.com/projectcalico/felix/blob/master/fv/health_test.go#L419, currently disabled because of the problem that this PR fixes.  Once this PR is merged, that FV test can be enabled again.
