### PR TITLE
Fix race in rebalancing test.

### DIFF
--- a/pkg/k8s/rebalance_test.go
+++ b/pkg/k8s/rebalance_test.go
@@ -90,6 +90,7 @@ var _ = Describe("Poll loop tests", func() {
 	})
 	It("should responds to changes", func() {
 		tickerC <- time.Now()
+		Eventually(server.MaxConns).Should(Equal([]int{31}))
 		k8sAPI.numNodes = 200
 		tickerC <- time.Now()
 		Eventually(server.MaxConns).Should(Equal([]int{31, 61}))


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Seen on this build: https://semaphoreci.com/calico/typha/branches/master/builds/81

Although the channel kicks the background thread before we set `numNodes = 200`, the write may still occur before the background thread reads it.  This results in the updates getting squashed.  Wait for the 31 to be emitted before doing the write.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
