### PR TITLE
Fix two issues that resulted in incorrect updateTypes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fd4f6449ebc0ab16f5b311b13f3febe047395a3311eeea3b25f2a84ad8fb2540
-updated: 2017-11-06T16:36:33.975232881-08:00
+hash: 20ff5a3f7c60ed99e3ebbaccde0d12df06eb955724b8eefcd2e47e2277b91786
+updated: 2017-11-07T15:45:58.953782657Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -42,8 +42,6 @@ imports:
   - log
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
-- name: github.com/gavv/monotime
-  version: 47d58efa69556a936a3c15eb2ed42706d968ab01
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
@@ -144,7 +142,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: c893efa28eb45626cdaa76c9f653b62488858837
+  version: 1eecca0ba8e6f5ea5a431ce21d3aee2af0b4c90b
   subpackages:
   - format
   - internal/assertion
@@ -211,13 +209,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell
@@ -231,12 +229,12 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/Workiva/go-datastructures
-  version: e47d01bc9eaf75e75e0f250e221dcb7533c7a1b8
+  version: af7475fb23e7561c87e7c1d17c12f46d732379bb
   subpackages:
   - list
   - trie/ctrie
 - name: golang.org/x/crypto
-  version: 1351f936d976c60a0a48d728281922cf63eafb8d
+  version: 687d4b818545e443c8ba223cbef20b1721afd4db
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -262,9 +260,10 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: e48874b42435b4347fc52bdee0424a52abc974d7
+  version: 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 4ee4af566555f5fbe026368b75596286a312663a
   subpackages:
@@ -291,7 +290,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
+  version: 9d8544a6b2c7df9cff240fcf92d7b2f59bc13416
   subpackages:
   - internal
   - internal/app_identity

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,11 +36,10 @@ import:
 - package: github.com/mipearson/rfw
 - package: github.com/prometheus/client_golang
   version: ^0.9.0-pre1
-- package: github.com/gavv/monotime
 - package: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9
 - package: github.com/Workiva/go-datastructures
-  version: ^1.0.39
+  version: af7475fb23e7561c87e7c1d17c12f46d732379bb
   subpackages:
   - trie/ctrie
 - package: golang.org/x/text

--- a/pkg/snapcache/cache.go
+++ b/pkg/snapcache/cache.go
@@ -358,7 +358,12 @@ func (c *Cache) publishBreadcrumb() {
 				counterUpdatesSkipped.Inc()
 				continue
 			}
-			c.kvs.Insert(keyAsBytes, newUpd)
+			// Since the purpose of the snapshot is to hold the initial set of updates to send to Felix at start-of-day,
+			// all the updates that it stores should have type UpdateTypeKVNew since they're all new to Felix. Copy
+			// the KV and adjust it before storing it in the snapshot.
+			updToStore := newUpd
+			updToStore.UpdateType = api.UpdateTypeKVNew
+			c.kvs.Insert(keyAsBytes, updToStore)
 		}
 
 		// Record the update in the new Breadcrumb so that clients following the chain of


### PR DESCRIPTION
## Description

- Force snapshot updates to have updateType=new, this makes sense because they are new to Felix even if they're the result of updates for Typha.  Add machinery to the FVs to check.

- The new machinery found a flake, which I tracked down to https://github.com/Workiva/go-datastructures/issues/180 pin go-datastructures to pick up the fix: https://github.com/Workiva/go-datastructures/pull/182.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Fixes #68 
Fixes #69

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [ ] Backport to 2.6.x
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Typha could send incorrect updateTypes to Felix during a snapshot leading some Felix statistics being incorrect.
```
