### PR TITLE
v0.5.x: Fix two issues that resulted in incorrect updateTypes

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 75c4773d69b229427767a6d90111abbef27e55064fa22af7d22d768c7aa94b38
-updated: 2017-10-31T11:52:33.23430979Z
+hash: 585e3889a5d85c43b7ad7e6b11d7c3c6f9a9b3cda6ca595b5bf4110b644c1d9d
+updated: 2017-11-07T18:49:44.298411325Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -199,7 +199,7 @@ imports:
   subpackages:
   - codec
 - name: github.com/Workiva/go-datastructures
-  version: e47d01bc9eaf75e75e0f250e221dcb7533c7a1b8
+  version: af7475fb23e7561c87e7c1d17c12f46d732379bb
   subpackages:
   - list
   - trie/ctrie
@@ -228,7 +228,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 95c6576299259db960f6c5b9b69ea52422860fce
+  version: 75813c647272dd855bda156405bf844a5414f5bf
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -411,7 +411,7 @@ imports:
   - util/jsonpath
 testImports:
 - name: github.com/onsi/gomega
-  version: 283ed655c6b8238afecd5bea6434bc9b03129f2f
+  version: 1eecca0ba8e6f5ea5a431ce21d3aee2af0b4c90b
   subpackages:
   - format
   - internal/assertion

--- a/glide.yaml
+++ b/glide.yaml
@@ -40,7 +40,7 @@ import:
 - package: github.com/onsi/ginkgo
   version: f40a49d81e5c12e90400620b6242fb29a8e7c9
 - package: github.com/Workiva/go-datastructures
-  version: ^1.0.39
+  version: v1.0.42
   subpackages:
   - trie/ctrie
 - package: golang.org/x/text

--- a/pkg/snapcache/cache.go
+++ b/pkg/snapcache/cache.go
@@ -358,7 +358,12 @@ func (c *Cache) publishBreadcrumb() {
 				counterUpdatesSkipped.Inc()
 				continue
 			}
-			c.kvs.Insert(keyAsBytes, newUpd)
+			// Since the purpose of the snapshot is to hold the initial set of updates to send to Felix at start-of-day,
+			// all the updates that it stores should have type UpdateTypeKVNew since they're all new to Felix. Copy
+			// the KV and adjust it before storing it in the snapshot.
+			updToStore := newUpd
+			updToStore.UpdateType = api.UpdateTypeKVNew
+			c.kvs.Insert(keyAsBytes, updToStore)
 		}
 
 		// Record the update in the new Breadcrumb so that clients following the chain of

--- a/pkg/snapcache/cache_test.go
+++ b/pkg/snapcache/cache_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/health"
+	"github.com/projectcalico/libcalico-go/lib/set"
 	"github.com/projectcalico/typha/pkg/syncproto"
 )
 
@@ -70,6 +71,16 @@ func (r *healthRecorder) LastReport() (rep health.HealthReport) {
 	return
 }
 
+func crumbToSnapshotUpdates(crumb *snapcache.Breadcrumb) []api.Update {
+	var snapshotUpdates []api.Update
+	for entry := range crumb.KVs.Iterator(nil) {
+		upd, err := entry.Value.(syncproto.SerializedUpdate).ToUpdate()
+		Expect(err).NotTo(HaveOccurred())
+		snapshotUpdates = append(snapshotUpdates, upd)
+	}
+	return snapshotUpdates
+}
+
 var _ = Describe("Snapshot cache FV tests", func() {
 	var cacheConfig snapcache.Config
 	var cache *snapcache.Cache
@@ -95,112 +106,129 @@ var _ = Describe("Snapshot cache FV tests", func() {
 		cancel()
 	})
 
-	It("should coalesce idempotent updates", func() {
-		kv := model.KVPair{
-			Key:      model.GlobalConfigKey{Name: "foo"},
-			Value:    "bar",
-			Revision: 10,
-			TTL:      0,
-		}
-		updateFoo1 := api.Update{
-			KVPair:     kv,
-			UpdateType: api.UpdateTypeKVNew,
-		}
-		cache.OnUpdates([]api.Update{updateFoo1})
-
-		// Wait for the update to flow through...
+	Describe("after sending GlobalConfigKey{foo}=bar @ rev 10", func() {
+		var kvFooBarRev10 model.KVPair
 		var crumb *snapcache.Breadcrumb
-		Eventually(func() bool {
-			crumb = cache.CurrentBreadcrumb()
-			return crumb.KVs.Size() > 0
-		}).Should(BeTrue())
+		var updateFooBarRev10 api.Update
 
-		// Then send in another update with same value, and another value to make sure we generate another
-		// crumb.
-		kv.Revision = 11
-		updateFoo2 := api.Update{
-			KVPair:     kv,
-			UpdateType: api.UpdateTypeKVUpdated,
-		}
+		BeforeEach(func() {
+			kvFooBarRev10 = model.KVPair{
+				Key:      model.GlobalConfigKey{Name: "foo"},
+				Value:    "bar",
+				Revision: 10,
+			}
+			updateFooBarRev10 = api.Update{
+				KVPair:     kvFooBarRev10,
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			cache.OnUpdates([]api.Update{updateFooBarRev10})
 
-		kv2 := model.KVPair{
-			Key:      model.GlobalConfigKey{Name: "biff"},
-			Value:    "baz",
-			Revision: 12,
-			TTL:      0,
-		}
-		updateBiff := api.Update{
-			KVPair:     kv2,
-			UpdateType: api.UpdateTypeKVNew,
-		}
-		cache.OnUpdates([]api.Update{updateFoo2, updateBiff})
+			// Wait for the update to flow through...
+			Eventually(func() bool {
+				crumb = cache.CurrentBreadcrumb()
+				crumbSize := crumb.KVs.Size()
+				// Check snapshot is read-only.
+				Expect(func() {
+					crumb.KVs.Insert([]byte("abcd"), "unused")
+				}).To(Panic())
+				log.WithField("crumb", crumb).WithField("size", crumbSize).Info("Current crumb now...")
+				Consistently(func() uint { return crumb.KVs.Size() }).Should(Equal(crumbSize))
+				return crumbSize > 0
+			}).Should(BeTrue())
+			log.WithField("crumb", crumb).Info("Got initial crumb")
 
-		// Make sure we don't block forever waiting on the next crumb...
-		go func() {
-			time.Sleep(10 * time.Second)
-			cancel()
-		}()
+			// Put a time limit on how long these tests wait.
+			go func() {
+				time.Sleep(10 * time.Second)
+				cancel()
+			}()
+		})
 
-		// Wait for the next crumb...
-		crumb, err := crumb.Next(cxt)
-		Expect(err).NotTo(HaveOccurred())
+		It("should coalesce idempotent updates", func() {
+			// Then send in another update with same value, and another value to make sure we generate another
+			// crumb.
+			kvFooBarRev11 := kvFooBarRev10
+			kvFooBarRev11.Revision = 11
+			updateFoo2 := api.Update{
+				KVPair:     kvFooBarRev11,
+				UpdateType: api.UpdateTypeKVUpdated,
+			}
 
-		// Its snapshot should contain both items...
-		snapshotUpdates := []api.Update{}
-		for entry := range crumb.KVs.Iterator(nil) {
-			upd, err := entry.Value.(syncproto.SerializedUpdate).ToUpdate()
+			updateBiff := api.Update{
+				KVPair: model.KVPair{
+					Key:      model.GlobalConfigKey{Name: "biff"},
+					Value:    "baz",
+					Revision: 12,
+					TTL:      0,
+				},
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			cache.OnUpdates([]api.Update{updateFoo2, updateBiff})
+
+			// Wait for the next crumb...
+			crumb, err := crumb.Next(cxt)
 			Expect(err).NotTo(HaveOccurred())
-			snapshotUpdates = append(snapshotUpdates, upd)
-		}
-		Expect(snapshotUpdates).To(ConsistOf(updateFoo1, updateBiff))
 
-		// Deltas should only contain the new update.
-		Expect(deserialiseUpdates(crumb.Deltas)).To(ConsistOf(updateBiff))
-	})
+			// Its snapshot should contain both items...
+			snapshotUpdates := crumbToSnapshotUpdates(crumb)
+			Expect(snapshotUpdates).To(ConsistOf(updateFooBarRev10, updateBiff))
 
-	It("should handle a delete", func() {
-		kv := model.KVPair{
-			Key:      model.GlobalConfigKey{Name: "foo"},
-			Value:    "bar",
-			Revision: 10,
-			TTL:      0,
-		}
-		updateFoo1 := api.Update{
-			KVPair:     kv,
-			UpdateType: api.UpdateTypeKVNew,
-		}
-		cache.OnUpdates([]api.Update{updateFoo1})
+			// Deltas should only contain the new update.
+			Expect(deserialiseUpdates(crumb.Deltas)).To(ConsistOf(updateBiff))
+		})
 
-		// Wait for the update to flow through...
-		var crumb *snapcache.Breadcrumb
-		Eventually(func() bool {
-			crumb = cache.CurrentBreadcrumb()
-			return crumb.KVs.Size() > 0
-		}).Should(BeTrue())
+		It("should coalesce the update types of non-idempotent updates", func() {
+			// Then send in another update with a new value.
+			kvFooUpdatedRev11 := model.KVPair{
+				Key:      model.GlobalConfigKey{Name: "foo"},
+				Value:    "updated",
+				Revision: 11,
+				TTL:      0,
+			}
+			updateFooUpdatedRev11 := api.Update{
+				KVPair:     kvFooUpdatedRev11,
+				UpdateType: api.UpdateTypeKVUpdated,
+			}
 
-		// Then send in another update with same value, and another value to make sure we generate another
-		// crumb.
-		kv.Revision = 11
-		kv.Value = nil
-		deletionUpdate := api.Update{
-			KVPair:     kv,
-			UpdateType: api.UpdateTypeKVDeleted,
-		}
-		cache.OnUpdates([]api.Update{deletionUpdate})
+			cache.OnUpdates([]api.Update{updateFooUpdatedRev11})
 
-		// Make sure we don't block forever waiting on the next crumb...
-		go func() {
-			time.Sleep(10 * time.Second)
-			cancel()
-		}()
+			// Wait for the next crumb...
+			crumb, err := crumb.Next(cxt)
+			Expect(err).NotTo(HaveOccurred())
 
-		// Wait for the next crumb...
-		crumb, err := crumb.Next(cxt)
-		Expect(err).NotTo(HaveOccurred())
+			// Its snapshot should contain the updated KV but with KV type new...
+			snapshotUpdates := crumbToSnapshotUpdates(crumb)
+			mergedUpdate := api.Update{
+				KVPair:     kvFooUpdatedRev11,
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			Expect(snapshotUpdates).To(ConsistOf(mergedUpdate))
 
-		// Its snapshot should be empty.
-		Expect(crumb.KVs.Size()).To(BeZero())
-		Expect(deserialiseUpdates(crumb.Deltas)).To(ConsistOf(deletionUpdate))
+			// Deltas should contain the update, not the merged version.
+			Expect(deserialiseUpdates(crumb.Deltas)).To(ConsistOf(updateFooUpdatedRev11))
+		})
+
+		It("should handle a delete", func() {
+			// Then send in another update with a deletion for the original value.
+			deletionUpdate := api.Update{
+				KVPair: model.KVPair{
+					Key:      model.GlobalConfigKey{Name: "foo"},
+					Revision: 11,
+				},
+				UpdateType: api.UpdateTypeKVDeleted,
+			}
+			cache.OnUpdates([]api.Update{deletionUpdate})
+
+			// Wait for the next crumb...
+			crumb, err := crumb.Next(cxt)
+			Expect(err).NotTo(HaveOccurred())
+			log.WithField("crumb", crumb).Info("Got crumb that should contain the deletion")
+
+			// Its snapshot should be empty.
+			snapshotUpdates := crumbToSnapshotUpdates(crumb)
+			Expect(snapshotUpdates).To(BeEmpty(), fmt.Sprintf("Deltas were: %#v", crumb.Deltas))
+			Expect(deserialiseUpdates(crumb.Deltas)).To(ConsistOf(deletionUpdate))
+		})
 	})
 
 	It("should report health eagerly", func() {
@@ -227,11 +255,18 @@ var _ = Describe("Snapshot cache FV tests", func() {
 
 	generateUpdates := func(num int) []api.Update {
 		var updates []api.Update
+		var seenKeys = set.New()
 		for i := 0; i < num; i++ {
 			configIdx := i % 100
 			value := fmt.Sprintf("config%v", i%55)
+			name := fmt.Sprintf("config%v", configIdx)
+			updateType := api.UpdateTypeKVNew
+			if seenKeys.Contains(name) {
+				updateType = api.UpdateTypeKVUpdated
+			}
+			seenKeys.Add(name)
 			key := model.GlobalConfigKey{
-				Name: fmt.Sprintf("config%v", configIdx),
+				Name: name,
 			}
 			upd := api.Update{
 				KVPair: model.KVPair{
@@ -240,7 +275,7 @@ var _ = Describe("Snapshot cache FV tests", func() {
 					Revision: i,
 					TTL:      0,
 				},
-				UpdateType: api.UpdateTypeKVNew,
+				UpdateType: updateType,
 			}
 			updates = append(updates, upd)
 		}
@@ -252,6 +287,7 @@ var _ = Describe("Snapshot cache FV tests", func() {
 		updates := generateUpdates(num)
 		expectedEndResult := map[model.Key]api.Update{}
 		for _, upd := range updates {
+			upd.UpdateType = api.UpdateTypeKVUnknown
 			expectedEndResult[upd.Key] = upd
 		}
 		for i := 0; i < len(updates); i += blockSize {
@@ -309,6 +345,7 @@ var _ = Describe("Snapshot cache FV tests", func() {
 				Expect(f.StateAsUpdates()).To(Equal(expectedEndResult),
 					fmt.Sprintf("Follower %s had incorrect state", f.name))
 				Expect(f.inSyncAt).To(Equal(maxRev))
+				Expect(f.problems).To(BeEmpty())
 			}
 		}
 
@@ -395,10 +432,13 @@ type follower struct {
 	targetLatency time.Duration
 
 	state    map[string]syncproto.SerializedUpdate
+	problems []string
 	inSyncAt int
 
 	loopStarted  bool
 	loopStartedC chan struct{}
+
+	maxRev int
 
 	wg *sync.WaitGroup
 }
@@ -409,27 +449,43 @@ func (f *follower) StateAsUpdates() map[model.Key]api.Update {
 		Expect(k).To(Equal(v.Key))
 		upd, err := v.ToUpdate()
 		Expect(err).NotTo(HaveOccurred())
+		// Followers won't agree on update types. If a follower joins after the final update of a KV then it'll see
+		// the KV as new where a follower that joined earlier should have got a UpdateTypeKVNew and then a
+		// UpdateTypeKVUpdate.
+		upd.UpdateType = api.UpdateTypeKVUnknown
 		actualState[upd.Key] = upd
 	}
 	return actualState
 }
 
+func (f *follower) storeKV(upd syncproto.SerializedUpdate) {
+	if _, ok := f.state[upd.Key]; !ok {
+		if upd.UpdateType != api.UpdateTypeKVNew {
+			f.problems = append(f.problems, fmt.Sprintf(
+				"First time we've seen this KV but update says it's an update: %#v", upd))
+		}
+	}
+	f.state[upd.Key] = upd
+	newRev, ok := upd.Revision.(int)
+	Expect(ok).To(BeTrue(), fmt.Sprintf("Update had bad revision %#v", upd))
+	if newRev > f.maxRev {
+		f.maxRev = newRev
+	}
+}
+
 func (f *follower) Loop(cxt context.Context) {
+	defer GinkgoRecover()
 	defer f.wg.Done()
 	logCxt := log.WithField("name", f.name)
 	time.Sleep(f.initialDelay)
 	crumb := f.cache.CurrentBreadcrumb()
 	logCxt.WithField("crumb", crumb.SequenceNumber).Info("Got first crumb")
 	done := false
-	maxRev := 0
 	for item := range crumb.KVs.Iterator(cxt.Done()) {
 		upd := item.Value.(syncproto.SerializedUpdate)
-		f.state[upd.Key] = upd
-		if upd.Revision.(int) > maxRev {
-			maxRev = upd.Revision.(int)
-		}
+		f.storeKV(upd)
 		if crumb.SyncStatus == api.InSync {
-			f.inSyncAt = maxRev
+			f.inSyncAt = f.maxRev
 			done = true
 		}
 	}
@@ -447,13 +503,10 @@ func (f *follower) Loop(cxt context.Context) {
 		crumb = newCrumb
 		//logCxt.WithField("crumb", crumb.SequenceNumber).Info("Got next crumb")
 		for _, upd := range crumb.Deltas {
-			f.state[upd.Key] = upd
-			if upd.Revision.(int) > maxRev {
-				maxRev = upd.Revision.(int)
-			}
+			f.storeKV(upd)
 		}
 		if crumb.SyncStatus == api.InSync {
-			f.inSyncAt = maxRev
+			f.inSyncAt = f.maxRev
 			done = true
 			logCxt.WithField("crumb", crumb.SequenceNumber).Info("Got final crumb")
 		}


### PR DESCRIPTION
Backport #70  to v0.5.x-series.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
- Force snapshot updates to have updateType=new, this makes sense
  because they are new to Felix even if they're the result of updates
  for Typha.  Add machinery to the FVs to check.

- The new machinery found a flake, which I tracked down to
  https://github.com/Workiva/go-datastructures/issues/180
  pin go-datastructures to pick up the fix:
  https://github.com/Workiva/go-datastructures/pull/182.

## Todos
- [x] Backport
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Typha could send duplicate updates to Felix under certain circumstances.
```
