### PR TITLE
Automated update of libcalico-go to 83fc14937b8584e65bd6c959c0a85256a 2d31e28

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cbd59040422e6c90ba3a6f350d948e29809edbd7da8e97b5ffe4d4e8d7354b4f
-updated: 2017-11-08T17:26:13.359330036-08:00
+hash: bd37fd49724e87880b6c82a01158dce115ef07638bbbfa1ab100e835ba2df173
+updated: 2017-11-09T12:32:40.644369-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -142,7 +142,7 @@ imports:
   - reporters/stenographer/support/go-isatty
   - types
 - name: github.com/onsi/gomega
-  version: c893efa28eb45626cdaa76c9f653b62488858837
+  version: 1eecca0ba8e6f5ea5a431ce21d3aee2af0b4c90b
   subpackages:
   - format
   - internal/assertion
@@ -168,7 +168,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: ad023dd397d2f3065c17c37e3cd14a960ae43482
+  version: 83fc14937b8584e65bd6c959c0a85256a2d31e28
   subpackages:
   - lib
   - lib/apiconfig

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: ad023dd397d2f3065c17c37e3cd14a960ae43482
+  version: 83fc14937b8584e65bd6c959c0a85256a2d31e28
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
Update of libcalico-go
