### PR TITLE
multi-architecture build in Makefile

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,18 +1,1 @@
-FROM alpine:3.4
-MAINTAINER Shaun Crampton <shaun@tigera.io>
-
-# Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
-RUN apk add --update tini
-ENTRYPOINT ["/sbin/tini", "--"]
-
-ADD typha.cfg /etc/calico/typha.cfg
-
-# Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
-# to more easily extract the build artefacts from the container.
-RUN mkdir /code
-ADD bin/calico-typha-amd64 /code
-WORKDIR /code
-RUN ln -s /code/calico-typha-amd64 /usr/bin/calico-typha
-
-# Run Typha by default
-CMD ["calico-typha"]
+Dockerfile-amd64

--- a/docker-image/Dockerfile-amd64
+++ b/docker-image/Dockerfile-amd64
@@ -1,0 +1,18 @@
+FROM alpine:3.6
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+
+# Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
+RUN apk add --update tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
+ADD typha.cfg /etc/calico/typha.cfg
+
+# Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
+# to more easily extract the build artefacts from the container.
+RUN mkdir /code
+ADD bin/calico-typha-amd64 /code
+WORKDIR /code
+RUN ln -s /code/calico-typha-amd64 /usr/bin/calico-typha
+
+# Run Typha by default
+CMD ["calico-typha"]

--- a/docker-image/Dockerfile-arm64
+++ b/docker-image/Dockerfile-arm64
@@ -1,0 +1,18 @@
+FROM alpine:3.6
+MAINTAINER Shaun Crampton <shaun@tigera.io>
+
+# Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
+RUN apk add --update tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
+ADD typha.cfg /etc/calico/typha.cfg
+
+# Put out binary in /code rather than directly in /usr/bin.  This allows the downstream builds
+# to more easily extract the build artefacts from the container.
+RUN mkdir /code
+ADD bin/calico-typha-arm64 /code
+WORKDIR /code
+RUN ln -s /code/calico-typha-arm64 /usr/bin/calico-typha
+
+# Run Typha by default
+CMD ["calico-typha"]


### PR DESCRIPTION
## Description
Add support for building typha on arm64. In addition, cleans up the Makefile to make it easy to build just the binary (separate from the docker image)

Depends on [go-build PR](https://github.com/projectcalico/go-build/pull/23) . Because the `arm64` go-build is not pushed out yet, built and ran it locally on both amd64 and arm64.

Ran tests with `make ut` as requested by @caseydavenport . All appear to pass and exit `0`.

Also updated the base alpine image to 3.6 from 3.4. 3.4 is old, but mainly because `alpine:3.4` doesn't exist as arm64 while `alpine:3.6` does.

Some notes:

1. I am not enamoured of the filename `bin/calico-typha-<arch>`, but it was that way before. Since this is built on one arch at a time anyways, I think a straight `bin/calico-typha` would be cleaner. As it is the `Dockerfile` creates a symlink anyways. I kept it the way it is though.
2. I tried to clean up the docker image tags to standard, so the architecture is defined in the tag, not the image name, while still keeping "arch-less" (the default) to be for amd64. In the future, of course, we can use multi-arch manifests to have all archs "just work". However, I am unsure if I get all the versioning dependencies right here, since I didn't fully understand how you do version tagging.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Upgrade Makefile to support automatic building on all architectures, including arm64.
```
