### PR TITLE
Update libcalico-go pin to 5f90a75a16b8c4b94fd045afbfbb545194b451ac

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 332cfe876d3ebbad12c4b33b87f32e48d6a783ca2b3548f6c381a30e359a8b3b
-updated: 2018-03-07T19:24:56.186317362Z
+hash: 2a499472cf4ae31de247dae6b1ab2361c9ec4f2ef50cef054f801af72bb297b0
+updated: 2018-03-08T15:57:08.552725872Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -33,7 +33,7 @@ imports:
   - pkg/types
   - version
 - name: github.com/coreos/go-semver
-  version: e214231b295a8ea9479f11b70b35d5acf3556d9b
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
   - semver
 - name: github.com/davecgh/go-spew
@@ -53,7 +53,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/go-ini/ini
-  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
+  version: 6333e38ac20b8949a8dd68baa3650f4dee8f39f0
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -178,7 +178,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 3be72c2105351f081f6e5c71e1fe036ca71ec343
+  version: 5f90a75a16b8c4b94fd045afbfbb545194b451ac
   subpackages:
   - lib
   - lib/apiconfig
@@ -263,7 +263,7 @@ imports:
   - list
   - trie/ctrie
 - name: golang.org/x/crypto
-  version: 85f98707c97e11569271e4d9b3d397e079c4f4d0
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: 3be72c2105351f081f6e5c71e1fe036ca71ec343
+  version: 5f90a75a16b8c4b94fd045afbfbb545194b451ac
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -336,3 +336,7 @@ type dummySyncer struct {
 func (*dummySyncer) Start() {
 
 }
+
+func (*dummySyncer) Stop() {
+
+}


### PR DESCRIPTION
## Description
Update libcalico-go pin to 5f90a75a16b8c4b94fd045afbfbb545194b451ac

## Todos

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
