### PR TITLE
Health server support custom host

### DIFF
--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -102,8 +102,10 @@ type Config struct {
 	LogSeverityScreen string `config:"oneof(DEBUG,INFO,WARNING,ERROR,CRITICAL);INFO"`
 	LogSeveritySys    string `config:"oneof(DEBUG,INFO,WARNING,ERROR,CRITICAL);INFO"`
 
-	HealthEnabled                   bool `config:"bool;false"`
-	HealthPort                      int  `config:"int(0,65535);9098"`
+	HealthEnabled bool   `config:"bool;false"`
+	HealthHost    string `config:"string;localhost"`
+	HealthPort    int    `config:"int(0,65535);9098"`
+
 	PrometheusMetricsEnabled        bool `config:"bool;false"`
 	PrometheusMetricsPort           int  `config:"int(0,65535);9093"`
 	PrometheusGoMetricsEnabled      bool `config:"bool;true"`

--- a/pkg/config/config_params_test.go
+++ b/pkg/config/config_params_test.go
@@ -68,6 +68,10 @@ var _ = DescribeTable("Config parsing",
 	Entry("LogSeveritySys", "LogSeveritySys", "error", "ERROR"),
 	Entry("LogSeveritySys", "LogSeveritySys", "critical", "CRITICAL"),
 
+	Entry("HealthEnabled", "HealthEnabled", "true", true),
+	Entry("HealthHost", "HealthHost", "127.0.0.1", "127.0.0.1"),
+	Entry("HealthPort", "HealthPort", "1234", int(1234)),
+
 	Entry("PrometheusMetricsEnabled", "PrometheusMetricsEnabled", "true", true),
 	Entry("PrometheusMetricsPort", "PrometheusMetricsPort", "1234", int(1234)),
 	Entry("PrometheusGoMetricsEnabled", "PrometheusGoMetricsEnabled", "false", false),

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -360,8 +360,11 @@ func (t *TyphaDaemon) Start(cxt context.Context) {
 	}
 
 	if t.ConfigParams.HealthEnabled {
-		log.WithField("port", t.ConfigParams.HealthPort).Info("Health enabled.  Starting server.")
-		t.healthAggregator.ServeHTTP(t.ConfigParams.HealthEnabled, "", t.ConfigParams.HealthPort)
+		log.WithFields(log.Fields{
+			"host": t.ConfigParams.HealthHost,
+			"port": t.ConfigParams.HealthPort,
+		}).Info("Health enabled.  Starting server.")
+		t.healthAggregator.ServeHTTP(t.ConfigParams.HealthEnabled, t.ConfigParams.HealthHost, t.ConfigParams.HealthPort)
 	}
 }
 


### PR DESCRIPTION
Instead of forcing to listen on all interfaces we should give the possibility for the user to make the health server listen on a specific host/ip.

Unit tests are added. Not sure what I can about the integration tests and release notes. Let me know how I can further help.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Typha now supports configuring both port and host to bind too for health checks.  The default is now localhost.
```