### PR TITLE
Use go-build 0.14. specifically to get go >=1.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(ARCH),x86_64)
     override ARCH=amd64
 endif
 
-GO_BUILD_VER ?= v0.10
+GO_BUILD_VER ?= v0.14
 join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 
 # for building, we use the go-build image for the *host* architecture, even if the target is different


### PR DESCRIPTION
I need go >=1.10 in order to pick up URI SAN handling in crypto/x509 (https://github.com/golang/go/commit/9e76ce70701ceef8fbccfb953b33a2ae7fe0367c)