### PR TITLE
Update libcalico-go to 5646fa11213b9b5314cca7f5b3aa28ea9811c908

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e37b0fba8b2fc2b67827ea2df7e18a26df4ffd2447922e1f3aaad2db4e215801
-updated: 2018-04-23T13:00:50.23810947Z
+hash: 7eb3e4d3043666043697e40004e8a7fbd13f1904cdc4c3aab40b3d990b63f0a6
+updated: 2018-05-03T21:53:07.324808089Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -34,7 +34,7 @@ imports:
   - pkg/types
   - version
 - name: github.com/coreos/go-semver
-  version: e214231b295a8ea9479f11b70b35d5acf3556d9b
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
   - semver
 - name: github.com/davecgh/go-spew
@@ -181,7 +181,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: e3351395c934cee118999b9d29508e9280fa75ec
+  version: 5646fa11213b9b5314cca7f5b3aa28ea9811c908
   subpackages:
   - lib
   - lib/apiconfig
@@ -237,7 +237,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: d0f7cd64bda49e08b22ae8a730aa57aa0db125d6
+  version: d811d2e9bf898806ecfb6ef6296774b13ffc314c
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -266,7 +266,7 @@ imports:
   - list
   - trie/ctrie
 - name: golang.org/x/crypto
-  version: 2b6c08872f4b66da917bb4ce98df4f0307330f78
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -322,7 +322,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: 0a24098c0ec68416ec050f567f75df563d6b231e
+  version: 962cbd1200af94a5a35ba8d512e9f91271b4d01a
   subpackages:
   - internal
   - internal/app_identity

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,7 +29,7 @@ import:
 - package: github.com/go-ini/ini
   version: ^1.21.0
 - package: github.com/projectcalico/libcalico-go
-  version: e3351395c934cee118999b9d29508e9280fa75ec
+  version: 5646fa11213b9b5314cca7f5b3aa28ea9811c908
   subpackages:
   - lib
 - package: github.com/sirupsen/logrus


### PR DESCRIPTION
Up the pin for `libcalico-go` for Typha. I believe this has to be done from the `projectcalico/typha` branch `automated-libcalico-update` so that we get the right pin of typha on Felix.