### PR TITLE
Use go-build 0.15, to fix build on non-amd64 platforms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(ARCH),x86_64)
     override ARCH=amd64
 endif
 
-GO_BUILD_VER ?= v0.14
+GO_BUILD_VER ?= v0.15
 join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 
 # for building, we use the go-build image for the *host* architecture, even if the target is different


### PR DESCRIPTION
Hi, I'm verifying native build on arm64 platform and find this minor issue:

The calico/go-build:v0.14-arm64 does not exist in the public
calico repository which causes build failure on arm64 platform.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
