### PR TITLE
Replicate all semaphore activities in ci and cd targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ sub-push-%:
 tag-images: imagetag
 	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(CONTAINER_NAME):$(IMAGETAG)-$(ARCH)
 	docker tag $(CONTAINER_NAME):latest-$(ARCH) quay.io/$(CONTAINER_NAME):$(IMAGETAG)-$(ARCH)
-	
+
 	# Tag images for gcr.io, used by GKE.
 	docker tag $(CONTAINER_NAME):latest-$(ARCH) gcr.io/projectcalico-org/$(CONTAINER_NAME):$(IMAGETAG)
 	docker tag $(CONTAINER_NAME):latest-$(ARCH) eu.gcr.io/projectcalico-org/$(CONTAINER_NAME):$(IMAGETAG)
@@ -311,8 +311,37 @@ ifndef COVERALLS_REPO_TOKEN
 endif
 	$(DOCKER_GO_BUILD) goveralls -repotoken=$(COVERALLS_REPO_TOKEN) -coverprofile=combined.coverprofile
 ###############################################################################
-# CI
+# CI/CD
 ###############################################################################
+
+.PHONY: cd ci version
+
+## checks that we can get the version
+version: image
+	docker run --rm $(CONTAINER_NAME):latest-$(ARCH) calico-typha --version
+
+## Builds the code and runs all tests.
+ci: image version static-checks ut upload-to-coveralls
+ifeq (,$(filter k8sfv-test, $(EXCEPT)))
+	@$(MAKE) k8sfv-test
+endif
+
+
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=$(BRANCH_NAME)
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
+k8sfv-tests: image
+	cd .. && git clone https://github.com/projectcalico/felix.git && cd felix; \
+	[ ! -e ../typha/semaphore-felix-branch ] || git checkout $(cat ../typha/semaphore-felix-branch); \
+	JUST_A_MINUTE=true USE_TYPHA=true FV_TYPHAIMAGE=calico/typha:latest TYPHA_VERSION=latest $(MAKE) k8sfv-test
 
 
 ###############################################################################


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Replicate the workflow from kube-controllers PR here:

* Create a `make ci` target that does everything in the various semaphore jobs except tag images and push to registries
* Create a `make cd` target that only tags images and pushes to registries

Should update Semaphore after merged.

As discussed with @caseydavenport @fasaxc @tomdee


## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
