### PR TITLE
Fix silly typo in Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ endif
 	$(MAKE) tag-images push IMAGETAG=$(BRANCH_NAME)
 	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
 
-k8sfv-tests: image
+k8sfv-test: image
 	cd .. && git clone https://github.com/projectcalico/felix.git && cd felix; \
 	[ ! -e ../typha/semaphore-felix-branch ] || git checkout $(cat ../typha/semaphore-felix-branch); \
 	JUST_A_MINUTE=true USE_TYPHA=true FV_TYPHAIMAGE=calico/typha:latest TYPHA_VERSION=latest $(MAKE) k8sfv-test


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

You cannot do this:

```Makefile
        @$(MAKE) k8sfv-test

# when you have a target that ends in 's'
k8sfv-tests: image
        cd .. && git clone https://github.com/projectcalico/felix.git && cd felix; \
        [ ! -e ../typha/semaphore-felix-branch ] || git checkout $(cat ../typha/semaphore-felix-branch); \
        JUST_A_MINUTE=true USE_TYPHA=true FV_TYPHAIMAGE=calico/typha:latest TYPHA_VERSION=latest $(MAKE) k8sfv-test
```

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```

cc @fasaxc 