### PR TITLE
Fix FV CA certs re: EKU

### DIFF
--- a/pkg/tlsutils/tlsutils.go
+++ b/pkg/tlsutils/tlsutils.go
@@ -137,8 +137,10 @@ func MakeCACert(name string) (*x509.Certificate, *rsa.PrivateKey) {
 		NotBefore: notBefore,
 		NotAfter:  notAfter,
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		// Must contain all key usages any child certs will contain. c.f. "nesting" comment on
+		// https://golang.org/pkg/crypto/x509/#VerifyOptions
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA: true,
 	}


### PR DESCRIPTION

## Description
Fixes Typha FVs so the CA cert contains the key usage for both server and client. Go 1.10.3 checks that the requested key usage appears in all chained certs when verifying.


## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
