### PR TITLE
ci and cd push all arches; ability to exclude specific

### DIFF
--- a/docker-image/Dockerfile.arm64
+++ b/docker-image/Dockerfile.arm64
@@ -1,13 +1,5 @@
-FROM alpine:3.7 as qemu
-
-ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le"
-
-RUN apk --update add curl
-
-# Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
-RUN chmod +x /usr/bin/qemu-*
+ARG QEMU_IMAGE=calico/go-build:latest
+FROM ${QEMU_IMAGE} as qemu
 
 FROM arm64v8/alpine:3.6 as base
 MAINTAINER Shaun Crampton <shaun@tigera.io>
@@ -16,7 +8,8 @@ MAINTAINER Shaun Crampton <shaun@tigera.io>
 # This must before any RUN command in this image!
 # we only need this for the intermediate "base" image, so we can run all the apk and other commands
 # and this is only because of using older kernels
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+# when running on a kernel >= 4.8, this will become less relevant
+COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
 RUN apk add --update tini

--- a/docker-image/Dockerfile.ppc64le
+++ b/docker-image/Dockerfile.ppc64le
@@ -1,13 +1,5 @@
-FROM alpine:3.7 as qemu
-
-ARG QEMU_VERSION=2.9.1-1
-ARG CROSS_ARCHS="aarch64 ppc64le"
-
-RUN apk --update add curl
-
-# Enable non-native runs on amd64 architecture hosts
-RUN for i in ${CROSS_ARCHS}; do curl -L https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-${i}-static.tar.gz | tar zxvf - -C /usr/bin; done
-RUN chmod +x /usr/bin/qemu-*
+ARG QEMU_IMAGE=calico/go-build:latest
+FROM ${QEMU_IMAGE} as qemu
 
 FROM ppc64le/alpine:3.6 as base
 MAINTAINER Shaun Crampton <shaun@tigera.io>
@@ -16,7 +8,8 @@ MAINTAINER Shaun Crampton <shaun@tigera.io>
 # This must before any RUN command in this image!
 # we only need this for the intermediate "base" image, so we can run all the apk and other commands
 # and this is only because of using older kernels
-COPY --from=qemu /usr/bin/qemu-*-static /usr/bin/
+# when running on a kernel >= 4.8, this will become less relevant
+COPY --from=qemu /usr/bin/qemu-ppc64le-static /usr/bin/
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
 RUN apk add --update tini

--- a/docker-image/Dockerfile.s390x
+++ b/docker-image/Dockerfile.s390x
@@ -1,5 +1,14 @@
+ARG QEMU_IMAGE=calico/go-build:latest
+FROM ${QEMU_IMAGE} as qemu
+
 FROM s390x/alpine:3.6
 MAINTAINER LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)
+
+# Enable non-native builds of this image on an amd64 hosts.
+# This must be the first RUN command in this file!
+# we only need this for the intermediate "base" image, so we can run all the apk and other commands
+# when running on a kernel >= 4.8, this will become less relevant
+COPY --from=qemu /usr/bin/qemu-s390x-static /usr/bin/
 
 # Since our binary isn't designed to run as PID 1, run it via the tini init daemon.
 RUN apk add --update tini


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

**note:** matches the [PR recently merged in for felix](https://github.com/projectcalico/felix/pull/1852)


#### Build and push by default for all supported arches
Before this PR, `ci` and `cd` targets build the binary and the image and push to registry _only_ for `amd64` unless explicitly choosing to add, e.g `make cd ARCH=arm64`. 

This PR makes `ci` and `cd` call the `*-all` targets, thus building binaries and images and pushing to registries for _all_ known arches.

#### Escape hatch to exclude arches
For example:

* `make cd` - push all known arches
* `make cd EXCLUDEARCH=arm64` - push all known arches except `arm64`
* `make cd EXCLUDEARCH="arm64 s390x"` - push all known arches except `arm64` and `s390x`

Same for `make ci`

#### Pull qemu from go-build instead of downloading every time
We have had the `qemu` binaries in `calico/go-build` since v0.15. Why redownload them? Just install them using multistage

#### Install only relevant qemu
Install only the relevant qemu binaries for the given arch, rather than all

#### Exclude s390x
Until such time as we can get `calico/go-build` to work with qemu (or any other interpreter), there is no point in trying to build here.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Build binaries and images, and push images, for all known arches.
```

cc @fasaxc @tomdee