### PR TITLE
Add a health check subcommand.

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
+	"strconv"
+
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
@@ -54,6 +56,8 @@ const usage = `Typha, Calico's fan-out proxy.
 
 Usage:
   calico-typha [options]
+  calico-typha check readiness [--port=<port>]
+  calico-typha check liveness [--port=<port>]
 
 Options:
   -c --config-file=<filename>  Config file to load [default: /etc/calico/typha.cfg].
@@ -84,6 +88,16 @@ type TyphaDaemon struct {
 
 	// Health monitoring.
 	healthAggregator *health.HealthAggregator
+
+	// healthCheckOnly is set to true if Typha is started as calico-typha check (readiness|liveness).
+	healthCheckOnly bool
+	// healthCheckType is set to "readiness" or "liveness" when parsing the calico-typha check command.
+	healthCheckType string
+	// healthCheckPort is set to the --port argument (or the default port).
+	healthCheckPort int
+
+	// OSExit is a shim for os.Exit().
+	OSExit func(int)
 }
 
 func New() *TyphaDaemon {
@@ -97,12 +111,16 @@ func New() *TyphaDaemon {
 		},
 		ConfigureEarlyLogging: logutils.ConfigureEarlyLogging,
 		ConfigureLogging:      logutils.ConfigureLogging,
+		OSExit:                os.Exit,
 	}
 }
 
 func (t *TyphaDaemon) InitializeAndServeForever(cxt context.Context) error {
 	t.DoEarlyRuntimeSetup()
 	t.ParseCommandLineArgs(nil)
+	if t.healthCheckOnly {
+		t.DoHealthCheckAndExit()
+	}
 	err := t.LoadConfiguration(cxt)
 	if err != nil { // Should only happen if context is canceled.
 		return err
@@ -134,6 +152,22 @@ func (t *TyphaDaemon) ParseCommandLineArgs(argv []string) {
 	if err != nil {
 		println(usage)
 		log.Fatalf("Failed to parse usage, exiting: %v", err)
+	}
+	if arguments["check"] == true {
+		t.healthCheckOnly = true
+		if arguments["liveness"] == true {
+			t.healthCheckType = "liveness"
+		} else {
+			t.healthCheckType = "readiness"
+		}
+		t.healthCheckPort = 9098
+		if portStr, ok := arguments["--port"].(string); ok {
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				log.Fatalf("Failed to parse --port argument: %v, exiting: %v", portStr, err)
+			}
+			t.healthCheckPort = port
+		}
 	}
 	t.ConfigFilePath = arguments["--config-file"].(string)
 	t.BuildInfoLogCxt = log.WithFields(log.Fields{
@@ -392,6 +426,27 @@ func (t *TyphaDaemon) WaitAndShutDown(cxt context.Context) {
 			return
 		}
 	}
+}
+func (t *TyphaDaemon) DoHealthCheckAndExit() {
+	url := fmt.Sprintf("http://127.0.0.1:%d/%s", t.healthCheckPort, t.healthCheckType)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.WithError(err).Error("Failed to make HTTP request for health URL")
+		t.OSExit(1)
+	}
+	var client http.Client
+	client.Timeout = time.Second
+	resp, err := client.Do(req)
+	if err != nil {
+		log.WithError(err).Error("Failed to get health URL")
+		t.OSExit(2)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		t.OSExit(0)
+	}
+
+	log.WithField("statusCode", resp.StatusCode).Error("Bad status code from health check URL")
+	t.OSExit(3)
 }
 
 // ClientV3Shim wraps a real client, allowing its syncer to be mocked.

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -235,29 +235,20 @@ var _ = Describe("Daemon", func() {
 
 var _ = Context("Healthcheck command", func() {
 	var d *TyphaDaemon
-	var exitRC int
 	var h *health.HealthAggregator
 	var port int
-
-	mockExit := func(rc int) {
-		exitRC = rc
-		panic("mockExit") // Need to panic to break out of the method.
-	}
 
 	healthcheckRC := func(kind string) int {
 		d.ParseCommandLineArgs([]string{
 			"check", kind, fmt.Sprintf("--port=%d", port),
 		})
-		Expect(d.DoHealthCheckAndExit).To(Panic())
-		return exitRC
+		return d.CalculateHealthRC()
 	}
 
 	BeforeEach(func() {
 		d = New()
 		logrus.SetOutput(GinkgoWriter)
 		logrus.SetLevel(logrus.DebugLevel)
-		d.OSExit = mockExit
-		exitRC = -1
 
 		h = health.NewHealthAggregator()
 		port = 19000 + GinkgoParallelNode()*1000 + rand.IntnRange(0, 1000)

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,9 +30,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/health"
 	"github.com/projectcalico/libcalico-go/lib/ipam"
 	"github.com/projectcalico/typha/fv-tests"
 	"github.com/projectcalico/typha/pkg/config"
@@ -226,6 +230,87 @@ var _ = Describe("Daemon", func() {
 				})
 			})
 		})
+	})
+})
+
+var _ = Context("Healthcheck command", func() {
+	var d *TyphaDaemon
+	var exitRC int
+	var h *health.HealthAggregator
+	var port int
+
+	mockExit := func(rc int) {
+		exitRC = rc
+		panic("mockExit") // Need to panic to break out of the method.
+	}
+
+	healthcheckRC := func(kind string) int {
+		d.ParseCommandLineArgs([]string{
+			"check", kind, fmt.Sprintf("--port=%d", port),
+		})
+		Expect(d.DoHealthCheckAndExit).To(Panic())
+		return exitRC
+	}
+
+	BeforeEach(func() {
+		d = New()
+		logrus.SetOutput(GinkgoWriter)
+		logrus.SetLevel(logrus.DebugLevel)
+		d.OSExit = mockExit
+		exitRC = -1
+
+		h = health.NewHealthAggregator()
+		port = 19000 + GinkgoParallelNode()*1000 + rand.IntnRange(0, 1000)
+		h.ServeHTTP(true, "127.0.0.1", port)
+		h.RegisterReporter("test", &health.HealthReport{Live: true, Ready: true}, 10*time.Second)
+
+		// Wait for the health server to start...
+		Eventually(func() int {
+			return healthcheckRC("liveness")
+		}).Should(Equal(0))
+	})
+
+	Context("with live and ready", func() {
+		BeforeEach(func() {
+			h.Report("test", &health.HealthReport{Live: true, Ready: true})
+		})
+
+		It("should report ready", func() {
+			Expect(healthcheckRC("readiness")).To(Equal(0))
+		})
+		It("should report live", func() {
+			Expect(healthcheckRC("liveness")).To(Equal(0))
+		})
+	})
+
+	Context("with live only", func() {
+		BeforeEach(func() {
+			h.Report("test", &health.HealthReport{Live: true, Ready: false})
+		})
+
+		It("should not report ready", func() {
+			Expect(healthcheckRC("readiness")).NotTo(Equal(0))
+		})
+		It("should report live", func() {
+			Expect(healthcheckRC("liveness")).To(Equal(0))
+		})
+	})
+
+	Context("with neither ready or live", func() {
+		BeforeEach(func() {
+			h.Report("test", &health.HealthReport{Live: false, Ready: false})
+		})
+
+		It("should not report ready", func() {
+			Expect(healthcheckRC("readiness")).NotTo(Equal(0))
+		})
+		It("should report live", func() {
+			Expect(healthcheckRC("liveness")).NotTo(Equal(0))
+		})
+	})
+
+	AfterEach(func() {
+		h.ServeHTTP(false, "127.0.0.1", port)
 	})
 })
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

The change in #140 caused the health endpoint to only listen on localhost.  However, the kubelet checks the health explicitly using the pod IP (which is actually the host IP since typha is host networked) resulting in connection refused.

This change adds a subcommand to the typha executable that checks the health endpoint at `http://127.0.0.1:<port>` so that we can use a [liveness/readiness command](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-command) instead of a HTTP check. I.e.

```
        livenessProbe:
          exec:
            command:
            - calico-typha
            - check
            - liveness
          periodSeconds: 30
          initialDelaySeconds: 30
        readinessProbe:
          exec:
            command:
            - calico-typha
            - check
            - readiness
          periodSeconds: 10
```

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan: Lance is adding a nightly k8s E2E run with typha.
- [x] Documentation
- [ ] ~Backport~
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Since Typha no longer exposes its readiness check on 0.0.0.0 (in order to improve security), our manifests have been updated to use a new command-line readiness check.
```
