### PR TITLE
Add multi-syncer support and BGP syncer

### DIFF
--- a/cmd/typha-client/typha-client.go
+++ b/cmd/typha-client/typha-client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	"github.com/projectcalico/typha/pkg/config"
 	"github.com/projectcalico/typha/pkg/logutils"
 	"github.com/projectcalico/typha/pkg/syncclient"
+	"github.com/projectcalico/typha/pkg/syncproto"
 )
 
 const usage = `Test client for Typha, Calico's fan-out proxy.
@@ -41,6 +42,7 @@ Usage:
 Options:
   --version                    Print the version and exit.
   --server=<ADDR>              Set the server to connect to [default: localhost:5473].
+  --type=<TYPE>                Use a particular syncer type.
 `
 
 type syncerCallbacks struct {
@@ -87,7 +89,14 @@ func main() {
 
 	callbacks := &syncerCallbacks{}
 	addr := arguments["--server"].(string)
-	client := syncclient.New(addr, buildinfo.GitVersion, "test-host", "some info", callbacks, nil)
+	var syncerType syncproto.SyncerType
+	if t, ok := arguments["--type"].(string); ok {
+		syncerType = syncproto.SyncerType(t)
+	}
+	options := &syncclient.Options{
+		SyncerType: syncerType,
+	}
+	client := syncclient.New(addr, buildinfo.GitVersion, "test-host", "some info", callbacks, options)
 	err = client.Start(context.Background())
 	if err != nil {
 		log.WithError(err).Panic("Client failed")

--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -156,11 +156,13 @@ var _ = Describe("With an in-process Server", func() {
 		cacheCxt, cacheCancel = context.WithCancel(context.Background())
 		valFilter = calc.NewValidationFilter(cache)
 		go decoupler.SendToContext(cacheCxt, valFilter)
-		server = syncserver.New(cache, syncserver.Config{
-			PingInterval: 10 * time.Second,
-			Port:         syncserver.PortRandom,
-			DropInterval: 50 * time.Millisecond,
-		})
+		server = syncserver.New(
+			map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache},
+			syncserver.Config{
+				PingInterval: 10 * time.Second,
+				Port:         syncserver.PortRandom,
+				DropInterval: 50 * time.Millisecond,
+			})
 		cache.Start(cacheCxt)
 		serverCxt, serverCancel = context.WithCancel(context.Background())
 		server.Start(serverCxt)
@@ -499,12 +501,14 @@ var _ = Describe("With an in-process Server with short ping timeout", func() {
 			// Reduce the wake up interval from the default to give us faster tear down.
 			WakeUpInterval: 50 * time.Millisecond,
 		})
-		server = syncserver.New(cache, syncserver.Config{
-			PingInterval: 100 * time.Millisecond,
-			PongTimeout:  500 * time.Millisecond,
-			Port:         syncserver.PortRandom,
-			DropInterval: 50 * time.Millisecond,
-		})
+		server = syncserver.New(
+			map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache},
+			syncserver.Config{
+				PingInterval: 100 * time.Millisecond,
+				PongTimeout:  500 * time.Millisecond,
+				Port:         syncserver.PortRandom,
+				DropInterval: 50 * time.Millisecond,
+			})
 		cacheCxt, cacheCancel = context.WithCancel(context.Background())
 		cache.Start(cacheCxt)
 		serverCxt, serverCancel = context.WithCancel(context.Background())
@@ -693,12 +697,14 @@ var _ = Describe("With an in-process Server with long ping interval", func() {
 			// Reduce the wake up interval from the default to give us faster tear down.
 			WakeUpInterval: 50 * time.Millisecond,
 		})
-		server = syncserver.New(cache, syncserver.Config{
-			PingInterval: 10000 * time.Second,
-			PongTimeout:  50000 * time.Second,
-			Port:         syncserver.PortRandom,
-			DropInterval: 1 * time.Second,
-		})
+		server = syncserver.New(
+			map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache},
+			syncserver.Config{
+				PingInterval: 10000 * time.Second,
+				PongTimeout:  50000 * time.Second,
+				Port:         syncserver.PortRandom,
+				DropInterval: 1 * time.Second,
+			})
 		cacheCxt, cacheCancel = context.WithCancel(context.Background())
 		cache.Start(cacheCxt)
 		serverCxt, serverCancel = context.WithCancel(context.Background())
@@ -913,16 +919,18 @@ var _ = Describe("with server requiring TLS", func() {
 		cacheCxt, cacheCancel = context.WithCancel(context.Background())
 		valFilter = calc.NewValidationFilter(cache)
 		go decoupler.SendToContext(cacheCxt, valFilter)
-		server = syncserver.New(cache, syncserver.Config{
-			PingInterval: 10 * time.Second,
-			Port:         syncserver.PortRandom,
-			DropInterval: 50 * time.Millisecond,
-			KeyFile:      filepath.Join(certDir, serverCertName+".key"),
-			CertFile:     filepath.Join(certDir, serverCertName+".crt"),
-			CAFile:       filepath.Join(certDir, "ca.crt"),
-			ClientCN:     requiredClientCN,
-			ClientURISAN: requiredClientURISAN,
-		})
+		server = syncserver.New(
+			map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache},
+			syncserver.Config{
+				PingInterval: 10 * time.Second,
+				Port:         syncserver.PortRandom,
+				DropInterval: 50 * time.Millisecond,
+				KeyFile:      filepath.Join(certDir, serverCertName+".key"),
+				CertFile:     filepath.Join(certDir, serverCertName+".crt"),
+				CAFile:       filepath.Join(certDir, "ca.crt"),
+				ClientCN:     requiredClientCN,
+				ClientURISAN: requiredClientURISAN,
+			})
 		cache.Start(cacheCxt)
 		serverCxt, serverCancel = context.WithCancel(context.Background())
 		server.Start(serverCxt)

--- a/glide.lock
+++ b/glide.lock
@@ -159,7 +159,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 0318a34ef4254a55e06a75f2f39d6285d2c4c8f0
+  version: 744044ba29c54a52fcbc60c0e2236258cf4c2da1
   subpackages:
   - lib/apiconfig
   - lib/apis/v1

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 91a8ddb45da019149af35b6dbe76f5c34d077747fe2d7d1daf5f6a5cde01633f
-updated: 2018-08-09T04:09:18.507064778Z
+hash: 511432f0208c1406f6e3536a26a314757f5336bc8141af48e5722bd3fbd8737f
+updated: 2018-08-08T14:27:17.882930053Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -7,7 +7,7 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/Azure/go-autorest
-  version: 1ff28809256a84bb6966640ff3d0371af82ccba4
+  version: d4e6b95c12a08b4de2d48b45d5b4d594e5d32fab
   subpackages:
   - autorest
   - autorest/adal
@@ -18,7 +18,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
-  version: 33245c6b5b49130ca99280408fadfab01aac0e48
+  version: fca8add78a9d926166eb739b8e4a124434025ba3
   subpackages:
   - auth/authpb
   - client
@@ -65,8 +65,6 @@ imports:
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
-- name: github.com/google/btree
-  version: 7d79101e329e5a3adf994758c578dab82b90c017
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
@@ -76,7 +74,7 @@ imports:
   - compiler
   - extensions
 - name: github.com/gophercloud/gophercloud
-  version: 781450b3c4fcb4f5182bcc5133adb4b2e4a09d1d
+  version: 6da026c32e2d622cc242d32984259c77237aefe1
   subpackages:
   - openstack
   - openstack/identity/v2/tenants
@@ -84,14 +82,12 @@ imports:
   - openstack/identity/v3/tokens
   - openstack/utils
   - pagination
-- name: github.com/gregjones/httpcache
-  version: 787624de3eb7bd915c329cba748687a3b22666a6
-  subpackages:
-  - diskcache
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
   - simplelru
+- name: github.com/howeyc/gopass
+  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/hpcloud/tail
   version: a1dbeea552b7c8df4b542c66073e393de198a800
   subpackages:
@@ -106,7 +102,7 @@ imports:
 - name: github.com/kardianos/osext
   version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/kelseyhightower/envconfig
-  version: dd1402a4d99de9ac2f396cd6fcb957bc2c695ec1
+  version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -154,8 +150,6 @@ imports:
   - types
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
-- name: github.com/peterbourgon/diskv
-  version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -165,7 +159,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: cac4ce6d0f2f1fdcaac2dcbe613374465cfd4953
+  version: 0318a34ef4254a55e06a75f2f39d6285d2c4c8f0
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -178,6 +172,7 @@ imports:
   - lib/backend/k8s/conversion
   - lib/backend/k8s/resources
   - lib/backend/model
+  - lib/backend/syncersv1/bgpsyncer
   - lib/backend/syncersv1/felixsyncer
   - lib/backend/syncersv1/updateprocessors
   - lib/backend/watchersyncer
@@ -245,7 +240,7 @@ imports:
   - list
   - trie/ctrie
 - name: golang.org/x/crypto
-  version: de0752318171da717af4ce24d0a2e8626afaeb11
+  version: f027049dab0ad238e394a753dba2d14753473a04
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -340,7 +335,7 @@ imports:
 - name: gopkg.in/fsnotify/fsnotify.v1
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/go-playground/validator.v8
-  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tomb.v1
@@ -348,7 +343,7 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
-  version: 072894a440bdee3a891dea811fe42902311cd2a3
+  version: 73d903622b7391f3312dcbac6483fed484e185f8
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
@@ -368,19 +363,19 @@ imports:
   - core/v1
   - events/v1beta1
   - extensions/v1beta1
+  - imagepolicy/v1alpha1
   - networking/v1
   - policy/v1beta1
   - rbac/v1
   - rbac/v1alpha1
   - rbac/v1beta1
   - scheduling/v1alpha1
-  - scheduling/v1beta1
   - settings/v1alpha1
   - storage/v1
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 103fd098999dc9c0c88536f5c9ad2e5da39373ae
+  version: 302974c03f7e50f16561ba237db776ab93594ef6
   subpackages:
   - pkg/api/errors
   - pkg/api/meta
@@ -423,7 +418,7 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65
+  version: 23781f4d6632d88e869066eaebb743857aa1ef9b
   subpackages:
   - discovery
   - kubernetes
@@ -452,14 +447,12 @@ imports:
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/rbac/v1beta1
   - kubernetes/typed/scheduling/v1alpha1
-  - kubernetes/typed/scheduling/v1beta1
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1alpha1
   - kubernetes/typed/storage/v1beta1
   - pkg/apis/clientauthentication
   - pkg/apis/clientauthentication/v1alpha1
-  - pkg/apis/clientauthentication/v1beta1
   - pkg/version
   - plugin/pkg/client/auth
   - plugin/pkg/client/auth/azure
@@ -482,7 +475,6 @@ imports:
   - transport
   - util/buffer
   - util/cert
-  - util/connrotation
   - util/flowcontrol
   - util/homedir
   - util/integer

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,7 +12,7 @@ import:
 - package: github.com/kardianos/osext
 - package: github.com/mipearson/rfw
 - package: github.com/projectcalico/libcalico-go
-  version: cac4ce6d0f2f1fdcaac2dcbe613374465cfd4953
+  version: feature-internal-rr
   subpackages:
   - lib/apiconfig
   - lib/backend/api
@@ -28,6 +28,18 @@ import:
   subpackages:
   - prometheus
   - prometheus/promhttp
+# prometheus/client_golang pulls in prometheus/client_model, which depends
+# on this version of golang/protobuf (but none of the prometheus repos provide
+# a dependency manifest). The genproto library (another indirect and unpinned 
+# dependency) also dpends on this version of protobuf.
+- package: github.com/golang/protobuf
+  version: v1.1.0
+# Another prometheus dependency; without this pin, floats to a master version that
+# is not compatible with glide.
+- package: github.com/prometheus/procfs
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+- package: github.com/prometheus/common
+  version: c7de2306084e37d54b8be01f3541a8464345e9a5
 - package: github.com/sirupsen/logrus
   # v1.0.5 causes test breakages.
   version: v1.0.4
@@ -35,11 +47,7 @@ import:
   subpackages:
   - pkg/apis/meta/v1
 - package: k8s.io/client-go
+  version: v7.0.0
   subpackages:
   - kubernetes
   - rest
-testImport:
-- package: github.com/onsi/ginkgo
-  subpackages:
-  - extensions/table
-- package: github.com/onsi/gomega

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -493,7 +493,7 @@ func (s ClientV3Shim) FelixSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Sy
 }
 
 func (s ClientV3Shim) BGPSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
-	return bgpsyncer.New(s.Backend(), callbacks, "", true)
+	return bgpsyncer.New(s.Backend(), callbacks, "", "")
 }
 
 // DatastoreClient is our interface to the datastore, used for mocking in the UTs.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/bgpsyncer"
 	"github.com/projectcalico/libcalico-go/lib/backend/syncersv1/felixsyncer"
 	"github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/health"
@@ -75,12 +76,9 @@ type TyphaDaemon struct {
 	ConfigParams    *config.Config
 
 	// The components of the server, created in CreateServer() below.
-	Syncer            bapi.Syncer
-	SyncerToValidator *calc.SyncerCallbacksDecoupler
-	Validator         *calc.ValidationFilter
-	ValidatorToCache  *calc.SyncerCallbacksDecoupler
-	FelixCache        *snapcache.Cache
-	Server            *syncserver.Server
+	SyncerPipelines    []*syncerPipeline
+	CachesBySyncerType map[syncproto.SyncerType]syncserver.BreadcrumbProvider
+	Server             *syncserver.Server
 
 	// The functions below default to real library functions but they can be overridden for testing.
 	NewClientV3           func(config apiconfig.CalicoAPIConfig) (DatastoreClient, error)
@@ -98,6 +96,28 @@ type TyphaDaemon struct {
 	healthCheckPort int
 }
 
+type syncerPipeline struct {
+	Type              syncproto.SyncerType
+	Syncer            bapi.Syncer
+	SyncerToValidator *calc.SyncerCallbacksDecoupler
+	Validator         *calc.ValidationFilter
+	ValidatorToCache  *calc.SyncerCallbacksDecoupler
+	Cache             *snapcache.Cache
+}
+
+func (p syncerPipeline) Start(cxt context.Context) {
+	logCxt := log.WithField("syncerType", p.Type)
+	logCxt.Info("Starting syncer")
+	p.Syncer.Start()
+	logCxt.Info("Starting syncer-to-validator decoupler")
+	go p.SyncerToValidator.SendTo(p.Validator)
+	logCxt.Info("Starting validator-to-cache decoupler")
+	go p.ValidatorToCache.SendTo(p.Cache)
+	logCxt.Info("Starting cache")
+	p.Cache.Start(cxt)
+	logCxt.Info("Started syncer pipeline")
+}
+
 func New() *TyphaDaemon {
 	return &TyphaDaemon{
 		NewClientV3: func(config apiconfig.CalicoAPIConfig) (DatastoreClient, error) {
@@ -109,6 +129,7 @@ func New() *TyphaDaemon {
 		},
 		ConfigureEarlyLogging: logutils.ConfigureEarlyLogging,
 		ConfigureLogging:      logutils.ConfigureLogging,
+		CachesBySyncerType:    map[syncproto.SyncerType]syncserver.BreadcrumbProvider{},
 	}
 }
 
@@ -327,37 +348,49 @@ configRetry:
 	return nil
 }
 
+func (t *TyphaDaemon) addSyncerPipeline(
+	syncerType syncproto.SyncerType,
+	newSyncer func(callbacks bapi.SyncerCallbacks) bapi.Syncer,
+) {
+	// Get a Syncer from the datastore, which will feed the validator layer with updates.
+	syncerToValidator := calc.NewSyncerCallbacksDecoupler()
+	syncer := newSyncer(syncerToValidator)
+	log.Debugf("Created Syncer: %#v", syncer)
+
+	// Create the validator, which sits between the syncer and the cache.
+	validatorToCache := calc.NewSyncerCallbacksDecoupler()
+	validator := calc.NewValidationFilter(validatorToCache)
+
+	// Create our snapshot cache, which stores point-in-time copies of the datastore contents.
+	cache := snapcache.New(snapcache.Config{
+		MaxBatchSize:     t.ConfigParams.SnapshotCacheMaxBatchSize,
+		HealthAggregator: t.healthAggregator,
+	})
+
+	pipeline := &syncerPipeline{
+		Type:              syncerType,
+		Syncer:            syncer,
+		SyncerToValidator: syncerToValidator,
+		Validator:         validator,
+		ValidatorToCache:  validatorToCache,
+		Cache:             cache,
+	}
+	t.SyncerPipelines = append(t.SyncerPipelines, pipeline)
+	t.CachesBySyncerType[syncerType] = cache
+}
+
 // CreateServer creates and configures (but does not start) the server components.
 func (t *TyphaDaemon) CreateServer() {
-	// Now create the Syncer; our caching layer and the TCP server.
-
 	// Health monitoring, for liveness and readiness endpoints.
 	t.healthAggregator = health.NewHealthAggregator()
 
-	caches := map[syncproto.SyncerType]syncserver.BreadcrumbProvider{}
-
-	{
-		// Get a Syncer from the datastore, which will feed the validator layer with updates.
-		t.SyncerToValidator = calc.NewSyncerCallbacksDecoupler()
-		t.Syncer = t.DatastoreClient.SyncerByIface(t.SyncerToValidator)
-		log.Debugf("Created Syncer: %#v", t.Syncer)
-
-		// Create the validator, which sits between the syncer and the cache.
-		t.ValidatorToCache = calc.NewSyncerCallbacksDecoupler()
-		t.Validator = calc.NewValidationFilter(t.ValidatorToCache)
-
-		// Create our snapshot cache, which stores point-in-time copies of the datastore contents.
-		t.FelixCache = snapcache.New(snapcache.Config{
-			MaxBatchSize:     t.ConfigParams.SnapshotCacheMaxBatchSize,
-			HealthAggregator: t.healthAggregator,
-		})
-
-		caches[syncproto.SyncerTypeFelix] = t.FelixCache
-	}
+	// Now create the Syncer and caching layer (one pipeline for each syncer we support).
+	t.addSyncerPipeline(syncproto.SyncerTypeFelix, t.DatastoreClient.FelixSyncerByIface)
+	t.addSyncerPipeline(syncproto.SyncerTypeBGP, t.DatastoreClient.BGPSyncerByIface)
 
 	// Create the server, which listens for connections from Felix.
 	t.Server = syncserver.New(
-		caches,
+		t.CachesBySyncerType,
 		syncserver.Config{
 			MaxMessageSize:          t.ConfigParams.ServerMaxMessageSize,
 			MinBatchingAgeThreshold: t.ConfigParams.ServerMinBatchingAgeThresholdSecs,
@@ -381,10 +414,9 @@ func (t *TyphaDaemon) CreateServer() {
 func (t *TyphaDaemon) Start(cxt context.Context) {
 	// Now we've connected everything up, start the background processing threads.
 	log.Info("Starting the datastore Syncer/cache layer")
-	t.Syncer.Start()
-	go t.SyncerToValidator.SendToContext(cxt, t.Validator)
-	go t.ValidatorToCache.SendToContext(cxt, t.FelixCache)
-	t.FelixCache.Start(cxt)
+	for _, s := range t.SyncerPipelines {
+		s.Start(cxt)
+	}
 	t.Server.Start(cxt)
 	if t.ConfigParams.ConnectionRebalancingMode == "kubernetes" {
 		log.Info("Kubernetes connection rebalancing is enabled, starting k8s poll goroutine.")
@@ -456,14 +488,19 @@ type ClientV3Shim struct {
 	RealClientV3
 }
 
-func (s ClientV3Shim) SyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
+func (s ClientV3Shim) FelixSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
 	return felixsyncer.New(s.Backend(), callbacks)
+}
+
+func (s ClientV3Shim) BGPSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
+	return bgpsyncer.New(s.Backend(), callbacks, "", true)
 }
 
 // DatastoreClient is our interface to the datastore, used for mocking in the UTs.
 type DatastoreClient interface {
 	clientv3.Interface
-	SyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer
+	FelixSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer
+	BGPSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer
 }
 
 // RealClientV3 is the real API of the V3 client, including the semi-private API that we use to get the backend.

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Daemon", func() {
 				Expect(d.SyncerToValidator).ToNot(BeNil())
 				Expect(d.ValidatorToCache).ToNot(BeNil())
 				Expect(d.Validator).ToNot(BeNil())
-				Expect(d.Cache).ToNot(BeNil())
+				Expect(d.FelixCache).ToNot(BeNil())
 				Expect(d.Server).ToNot(BeNil())
 			})
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -149,6 +149,8 @@ var _ = Describe("Daemon", func() {
 					Expect(p.Cache).ToNot(BeNil())
 				}
 				Expect(d.Server).ToNot(BeNil())
+				Expect(datastore.bgpSyncerCalled).To(BeTrue())
+				Expect(datastore.felixSyncerCalled).To(BeTrue())
 			})
 
 			It("should start a working server", func() {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -139,12 +139,15 @@ var _ = Describe("Daemon", func() {
 
 			It("should create the server components", func() {
 				d.CreateServer()
-				Expect(d.SyncerToValidator).ToNot(BeNil())
-				Expect(d.Syncer).ToNot(BeNil())
-				Expect(d.SyncerToValidator).ToNot(BeNil())
-				Expect(d.ValidatorToCache).ToNot(BeNil())
-				Expect(d.Validator).ToNot(BeNil())
-				Expect(d.FelixCache).ToNot(BeNil())
+				Expect(d.SyncerPipelines).To(HaveLen(2))
+				for _, p := range d.SyncerPipelines {
+					Expect(p.SyncerToValidator).ToNot(BeNil())
+					Expect(p.Syncer).ToNot(BeNil())
+					Expect(p.SyncerToValidator).ToNot(BeNil())
+					Expect(p.ValidatorToCache).ToNot(BeNil())
+					Expect(p.Validator).ToNot(BeNil())
+					Expect(p.Cache).ToNot(BeNil())
+				}
 				Expect(d.Server).ToNot(BeNil())
 			})
 
@@ -178,7 +181,7 @@ var _ = Describe("Daemon", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Send in an update at the top of the processing pipeline.
-				d.SyncerToValidator.OnStatusUpdated(bapi.InSync)
+				d.SyncerPipelines[0].SyncerToValidator.OnStatusUpdated(bapi.InSync)
 				// It should make it all the way through to our recorder.
 				Eventually(cbs.Status).Should(Equal(bapi.InSync))
 			})
@@ -306,16 +309,24 @@ var _ = Context("Healthcheck command", func() {
 })
 
 type mockDatastore struct {
-	mutex        sync.Mutex
-	syncerCalled bool
-	initCalled   int
-	failInit     bool
+	mutex             sync.Mutex
+	bgpSyncerCalled   bool
+	felixSyncerCalled bool
+	initCalled        int
+	failInit          bool
 }
 
-func (b *mockDatastore) SyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
+func (b *mockDatastore) FelixSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-	b.syncerCalled = true
+	b.felixSyncerCalled = true
+	return &dummySyncer{}
+}
+
+func (b *mockDatastore) BGPSyncerByIface(callbacks bapi.SyncerCallbacks) bapi.Syncer {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	b.bgpSyncerCalled = true
 	return &dummySyncer{}
 }
 

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -103,8 +103,11 @@ func New(
 		options = &Options{}
 	}
 	return &SyncerClient{
-		ID:        id,
-		logCxt:    log.WithField("connID", id),
+		ID: id,
+		logCxt: log.WithFields(log.Fields{
+			"connID": id,
+			"type":   options.SyncerType,
+		}),
 		callbacks: cbs,
 		addr:      addr,
 

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ type Options struct {
 	CAFile       string
 	ServerCN     string
 	ServerURISAN string
+	SyncerType   syncproto.SyncerType
 }
 
 func (o *Options) readTimeout() time.Duration {
@@ -98,6 +99,9 @@ func New(
 	}
 	id := nextID
 	nextID++
+	if options == nil {
+		options = &Options{}
+	}
 	return &SyncerClient{
 		ID:        id,
 		logCxt:    log.WithField("connID", id),
@@ -263,11 +267,16 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 	s.encoder = gob.NewEncoder(s.connection)
 	s.decoder = gob.NewDecoder(s.connection)
 
+	ourSyncerType := s.options.SyncerType
+	if ourSyncerType == "" {
+		ourSyncerType = syncproto.SyncerTypeFelix
+	}
 	err := s.sendMessageToServer(cxt, logCxt, "send hello to server",
 		syncproto.MsgClientHello{
-			Hostname: s.myHostname,
-			Version:  s.myVersion,
-			Info:     s.myInfo,
+			Hostname:   s.myHostname,
+			Version:    s.myVersion,
+			Info:       s.myInfo,
+			SyncerType: ourSyncerType,
 		},
 	)
 	if err != nil {
@@ -311,6 +320,20 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 			s.callbacks.OnUpdates(updates)
 		case syncproto.MsgServerHello:
 			logCxt.WithField("serverVersion", msg.Version).Info("Server hello message received")
+
+			// Check the SyncerType reported by the server.  If the server is too old to support SyncerType then
+			// the message will have an empty string in place of the SyncerType.  In that case we only proceed if
+			// the client wants the felix syncer.
+			serverSyncerType := msg.SyncerType
+			if serverSyncerType == "" {
+				logCxt.Info("Server responded without SyncerType, assuming an old Typha version that only " +
+					"supports SyncerTypeFelix.")
+				serverSyncerType = syncproto.SyncerTypeFelix
+			}
+			if ourSyncerType != serverSyncerType {
+				logCxt.Error("We require SyncerType %s but Typha server doesn't support it.", ourSyncerType)
+				return
+			}
 		}
 	}
 }

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -192,13 +192,28 @@ type Envelope struct {
 	Message interface{}
 }
 
+type SyncerType string
+
+const (
+	SyncerTypeFelix SyncerType = "felix"
+	SyncerTypeBGP   SyncerType = "bgp"
+)
+
 type MsgClientHello struct {
 	Hostname string
 	Info     string
 	Version  string
+
+	// SyncerType the requested syncer type.  Added in v3.3; if client doesn't providea value, assumed to be
+	// SyncerTypeFelix.
+	SyncerType SyncerType
 }
 type MsgServerHello struct {
 	Version string
+
+	// SyncerType the active syncer type; if not specified, implies that the server is an older Typha instance that
+	// only supports SyncerTypeFelix.
+	SyncerType SyncerType
 }
 type MsgSyncStatus struct {
 	SyncStatus api.SyncStatus

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -204,7 +204,7 @@ type MsgClientHello struct {
 	Info     string
 	Version  string
 
-	// SyncerType the requested syncer type.  Added in v3.3; if client doesn't providea value, assumed to be
+	// SyncerType the requested syncer type.  Added in v3.3; if client doesn't provide a value, assumed to be
 	// SyncerTypeFelix.
 	SyncerType SyncerType
 }

--- a/utils/run-coverage
+++ b/utils/run-coverage
@@ -21,7 +21,7 @@ test_pkgs=$(go list -f '{{ if .TestGoFiles | or .XTestGoFiles }}{{ .ImportPath }
 test ! -z "$test_pkgs"
 echo "Packages with tests: $test_pkgs"
 
-ginkgo -cover -covermode=count -coverpkg=${go_dirs} -r -p
+ginkgo -cover -covermode=count -coverpkg=${go_dirs} ${GINKGO_ARGS} -r
 gocovmerge $(find . -name '*.coverprofile') > combined.coverprofile
 
 # Print the coverage.  We use sed to remove the verbose prefix and trim down


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Add support for multiple syncer types in Typha and add the BGP syncer.  The client can now request a particular syncer type in its ClientHello message and Typha will respond with the syncer type in its hello message so that the client can verify server support.  (This approach avoids needing to make a breaking change to the protocol since gob ignores unknown fields and we default the the felix syncer if the field is not present.)

Implementation:

- Each syncer gets a separate cache pipeline and separate "breadcrumb" cache.
- The connection handling component passes a map of caches to the individual connection so it can select the right one based on the handshake.

## Todos
- [ ] Update libcalico-go pin after libcalico-go PR is merged.
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [x] Documentation
- [ ] ~Backport~
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
