### PR TITLE
Don't interpret glide WARN as a problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ DOCKER_RUN := mkdir -p .go-pkg-cache && \
                               --net=host \
                               $(EXTRA_DOCKER_ARGS) \
                               -e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+                              -v $(HOME)/.glide:/home/user/.glide:rw \
                               -v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
                               -v $(CURDIR)/.go-pkg-cache:/go/pkg:rw \
                               -w /go/src/$(PACKAGE_NAME) \
@@ -212,9 +213,7 @@ update-libcalico:
             if [ $(LIBCALICO_REPO) != "github.com/projectcalico/libcalico-go" ]; then \
               glide mirror set https://github.com/projectcalico/libcalico-go $(LIBCALICO_REPO) --vcs git; glide mirror list; \
             fi;\
-          OUTPUT=`mktemp`;\
-          glide up --strip-vendor; glide up --strip-vendor 2>&1 | tee $$OUTPUT; \
-          if ! grep "\[WARN\]" $$OUTPUT; then true; else false; fi; \
+          glide up --strip-vendor || glide up --strip-vendor; \
         fi'
 
 bin/calico-typha: bin/calico-typha-$(ARCH)


### PR DESCRIPTION
Doing so causes our CI and automatic updating to fail unnecessarily.

1. From the perspective of "shall we commit this automatic update or
not", the relevant test is whether "make test" passes following "make
update-libcalico", and the Semaphore triggers already have this logic;
i.e. they only commit and push the glide.yaml and glide.lock changes if
"make test" passes.

2. When the automatic process fails, and I do it manually instead, I've
seen many cases where the glide update emits both WARNs and ERRORs, but
the glide.lock and glide.yaml are as expected and "make test" still
passes anyway.  Hence there are many cases where WARNs and ERRORs are
benign.

3. We can avoid tripping over benign WARNs by removing the extra grep,
as in this commit.  Then the remaining conditions will be (a) that glide
itself completes with successful exit status, and (b) that "make test"
passes following the update.  Which I believe is what we want.

Also:
- map in the Glide cache
- only run glide up twice if the first time fails
