### PR TITLE
Rev libcalico-go to 3655574dc6162df9974bbdebab072b5ee104b554

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -135,7 +135,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: edf3017e0fdba18ffd96694c9215623e06404f59 
+  version: 3655574dc6162df9974bbdebab072b5ee104b554
   subpackages:
   - lib
   - lib/api


### PR DESCRIPTION
## Description

Rev libcalico-go. Had to do this manually of glide running into some issues pulling conflicting deps. Looks like there is precedent to this in prior commits as well.