### PR TITLE
create tmp dir to prevent crash from glog 

### DIFF
--- a/docker-image/Dockerfile.amd64
+++ b/docker-image/Dockerfile.amd64
@@ -5,6 +5,7 @@ MAINTAINER Shaun Crampton <shaun@tigera.io>
 RUN apk add --update tini
 
 FROM scratch
+COPY --from=base /tmp /tmp
 COPY --from=base /sbin/tini /sbin/tini
 COPY --from=base /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
 COPY --from=base /lib/libc.musl-x86_64.so.1 /lib/libc.musl-x86_64.so.1


### PR DESCRIPTION
## Description
- addresses the issue raised by https://github.com/projectcalico/typha/issues/196
- was able to verify that this change prevents typha from crashing when apiserver goes down.

## Release Note

```release-note
- fixes a bug where typha would crash when kube-apiserver goes down
```
