### PR TITLE
Disable Glog logging to disk

### DIFF
--- a/docker-image/Dockerfile.amd64
+++ b/docker-image/Dockerfile.amd64
@@ -7,7 +7,6 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-stati
 RUN chmod +x /sbin/tini
 
 FROM scratch
-COPY --from=base /tmp /tmp
 COPY --from=base /sbin/tini /sbin/tini
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds

--- a/docker-image/Dockerfile.arm64
+++ b/docker-image/Dockerfile.arm64
@@ -17,7 +17,6 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-stati
 RUN chmod +x /sbin/tini
 
 FROM scratch
-COPY --from=base /tmp /tmp
 COPY --from=base /sbin/tini /sbin/tini
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds

--- a/docker-image/Dockerfile.ppc64le
+++ b/docker-image/Dockerfile.ppc64le
@@ -17,7 +17,6 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-stati
 RUN chmod +x /sbin/tini
 
 FROM scratch
-COPY --from=base /tmp /tmp
 COPY --from=base /sbin/tini /sbin/tini
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds

--- a/docker-image/Dockerfile.s390x
+++ b/docker-image/Dockerfile.s390x
@@ -17,7 +17,6 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-stati
 RUN chmod +x /sbin/tini
 
 FROM scratch
-COPY --from=base /tmp /tmp
 COPY --from=base /sbin/tini /sbin/tini
 
 # Put our binary in /code rather than directly in /usr/bin.  This allows the downstream builds

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -58,6 +58,7 @@ const logQueueSize = 100
 // ConfigureEarlyLogging installs our logging adapters, and enables early logging to screen
 // if it is enabled by either the TYPHA_EARLYLOGSEVERITYSCREEN or TYPHA_LOGSEVERITYSCREEN
 // environment variable.
+// It also disables glog's log to disk default behaviour.
 func ConfigureEarlyLogging() {
 	// Log to stdout.  This prevents fluentd, for example, from interpreting all our logs as errors by default.
 	log.SetOutput(os.Stdout)

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -16,6 +16,7 @@ package logutils
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io"
 	"log/syslog"
@@ -90,6 +91,14 @@ func ConfigureEarlyLogging() {
 	}
 	log.SetLevel(logLevelScreen)
 	log.Infof("Early screen log level set to %v", logLevelScreen)
+
+	// Disable to disk logging by glog - this will need to be updated if client-go is
+	// updated to a version making use of klog ( see https://github.com/projectcalico/kube-controllers/pull/362 for more info )
+	err := flag.Set("logtostderr", "true")
+	if err != nil {
+		log.WithError(err).Fatal("Failed to configure logging")
+	}
+	log.Infof("glog logging to disk disabled")
 }
 
 // ConfigureLogging uses the resolved configuration to complete the logging


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Tidy up the solution to #196 . Let me know if this isn't the best place in the codebase for this.

Removes the /tmp dir copy from the base image which is only done to handle glog writing logs to disk.

Instead adds disabling of glog's write to disk behaviour to `ConfigureEarlyLogging` to disable the behaviour as fast as possible. Same behaviour as now used by [kube-controllers](https://github.com/projectcalico/kube-controllers) after https://github.com/projectcalico/kube-controllers/pull/361
This repo isn't yet using a new enough version of client-go to need the klog behaviour disabling but have left a comment in the glog disabling.

Tested successfully in our cluster both with just removing the tmp dir and causing the expected crash of the pod and with the new code.

<details>
<summary>Successful logs</summary>
```
E0328 15:21:05.212013       8 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=75, ErrCode=NO_ERROR, debug=""
E0328 15:21:05.212023       8 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=75, ErrCode=NO_ERROR, debug=""
E0328 15:21:05.212183       8 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=75, ErrCode=NO_ERROR, debug=""
2019-03-28 15:21:05.212 [INFO][8] watchercache.go 242: Failed to create watcher ListRoot="/calico/resources/v3/projectcalico.org/workloadendpoints" error=Get https://*:443/api/v1/pods?resourceVersion=* &watch=true: dial tcp *:443: connect: connection refused performFullResync=false
```
</details>

<details>
<summary>Crashing Logs</summary>
```
E0328 15:12:49.887295       8 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=125, ErrCode=NO_ERROR, debug=""
E0328 15:12:49.887295       8 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=125, ErrCode=NO_ERROR, debug=""
log: exiting because of error: log: cannot create log: open /tmp/calico-typha.ip-10-41-40-202.unknownuser.log.ERROR.20190328-151249.8: no such file or directory
```
</details>

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
