### PR TITLE
Use calico fork of logrus

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -242,7 +242,8 @@ imports:
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: 1f80e3709dfafa8ca8727ba7eb392a11827ac8e2
+  repo: https://github.com/projectcalico/logrus
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
 - name: github.com/ugorji/go

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,9 +28,12 @@ import:
   subpackages:
   - prometheus
   - prometheus/promhttp
+# Use our fork, because v1.0.5 causes test breakages due to problems with our log formatting code,
+# but other deps require newer version because of the SetOutput function. Our fork backports
+# the missing stuff on top of v1.0.4.
 - package: github.com/sirupsen/logrus
-  # v1.0.5 causes test breakages.
-  version: v1.0.4
+  repo: https://github.com/projectcalico/logrus
+  version: v1.0.4-calico
 - package: k8s.io/apimachinery
   subpackages:
   - pkg/apis/meta/v1


### PR DESCRIPTION
This is to fix issues with missing file and line number information
after bumping the version to 1.0.6.

See https://github.com/projectcalico/libcalico-go/pull/1074