### PR TITLE
Make prometheus host input validation generic and apply it to HealthHost

### DIFF
--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -30,11 +30,11 @@ import (
 )
 
 var (
-	IfaceListRegexp      = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,15}(,[a-zA-Z0-9_-]{1,15})*$`)
-	AuthorityRegexp      = regexp.MustCompile(`^[^:/]+:\d+$`)
-	HostnameRegexp       = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
-	StringRegexp         = regexp.MustCompile(`^.*$`)
-	PrometheusHostRegexp = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,64}$`)
+	IfaceListRegexp   = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,15}(,[a-zA-Z0-9_-]{1,15})*$`)
+	AuthorityRegexp   = regexp.MustCompile(`^[^:/]+:\d+$`)
+	HostnameRegexp    = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+	StringRegexp      = regexp.MustCompile(`^.*$`)
+	HostAddressRegexp = regexp.MustCompile(`^[a-zA-Z0-9:._+-]{1,64}$`)
 )
 
 const (
@@ -104,11 +104,11 @@ type Config struct {
 	LogSeveritySys    string `config:"oneof(DEBUG,INFO,WARNING,ERROR,CRITICAL);INFO"`
 
 	HealthEnabled bool   `config:"bool;false"`
-	HealthHost    string `config:"string;localhost"`
+	HealthHost    string `config:"host-address;localhost"`
 	HealthPort    int    `config:"int(0,65535);9098"`
 
 	PrometheusMetricsEnabled        bool   `config:"bool;false"`
-	PrometheusMetricsHost           string `config:"prometheus-host;"`
+	PrometheusMetricsHost           string `config:"host-address;"`
 	PrometheusMetricsPort           int    `config:"int(0,65535);9093"`
 	PrometheusGoMetricsEnabled      bool   `config:"bool;true"`
 	PrometheusProcessMetricsEnabled bool   `config:"bool;true"`
@@ -427,9 +427,9 @@ func loadParams() {
 		case "string":
 			param = &RegexpParam{Regexp: StringRegexp,
 				Msg: "invalid string"}
-		case "prometheus-host":
-			param = &RegexpParam{Regexp: PrometheusHostRegexp,
-				Msg: "invalid host for Prometheus"}
+		case "host-address":
+			param = &RegexpParam{Regexp: HostAddressRegexp,
+				Msg: "invalid host address"}
 		default:
 			log.Panicf("Unknown type of parameter: %v", kind)
 		}


### PR DESCRIPTION
Using joinHostPort allows us to reuse input validation on HealthHost as well.
