### PR TITLE
Support node resource update handling in handshake

### DIFF
--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"sync"
@@ -116,6 +117,9 @@ func New(
 		myInfo:     myInfo,
 
 		options: options,
+		handshakeStatus: &handshakeStatus{
+			helloReceivedChan: make(chan struct{}, 1),
+		},
 	}
 }
 
@@ -126,12 +130,19 @@ type SyncerClient struct {
 	myHostname, myVersion, myInfo string
 	options                       *Options
 
-	connection net.Conn
-	encoder    *gob.Encoder
-	decoder    *gob.Decoder
+	connection                  net.Conn
+	encoder                     *gob.Encoder
+	decoder                     *gob.Decoder
+	handshakeStatus             *handshakeStatus
+	supportsNodeResourceUpdates bool
 
 	callbacks api.SyncerCallbacks
 	Finished  sync.WaitGroup
+}
+
+type handshakeStatus struct {
+	helloReceivedChan chan struct{}
+	complete          bool
 }
 
 func (s *SyncerClient) Start(cxt context.Context) error {
@@ -163,6 +174,26 @@ func (s *SyncerClient) Start(cxt context.Context) error {
 		s.Finished.Done()
 	}()
 	return nil
+}
+
+// SupportsNodeResourceUpdates waits for the Typha server to send a hello and returns true if
+// the server supports node resource updates. If the given timeout is reached, an error is returned.
+func (s *SyncerClient) SupportsNodeResourceUpdates(timeout time.Duration) (bool, error) {
+	// If we've already gotten a MsgServerHello just return with the value
+	if s.handshakeStatus.complete {
+		return s.supportsNodeResourceUpdates, nil
+	}
+
+	select {
+	case <-s.handshakeStatus.helloReceivedChan:
+		s.logCxt.Debug("Received MsgServerHello from server")
+		s.handshakeStatus.complete = true
+		return s.supportsNodeResourceUpdates, nil
+	case <-time.After(timeout):
+		// fallthrough
+	}
+
+	return false, fmt.Errorf("Timed out waiting for handshake to complete")
 }
 
 func (s *SyncerClient) connect(cxt context.Context) error {
@@ -323,6 +354,13 @@ func (s *SyncerClient) loop(cxt context.Context, cancelFn context.CancelFunc) {
 			s.callbacks.OnUpdates(updates)
 		case syncproto.MsgServerHello:
 			logCxt.WithField("serverVersion", msg.Version).Info("Server hello message received")
+
+			// Check whether Typha supports node resource updates.
+			if !msg.SupportsNodeResourceUpdates {
+				logCxt.Info("Server responded without support for node resource updates, assuming older Typha")
+			}
+			s.supportsNodeResourceUpdates = msg.SupportsNodeResourceUpdates
+			s.handshakeStatus.helloReceivedChan <- struct{}{}
 
 			// Check the SyncerType reported by the server.  If the server is too old to support SyncerType then
 			// the message will have an empty string in place of the SyncerType.  In that case we only proceed if

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -179,7 +179,7 @@ func (s *SyncerClient) Start(cxt context.Context) error {
 // SupportsNodeResourceUpdates waits for the Typha server to send a hello and returns true if
 // the server supports node resource updates. If the given timeout is reached, an error is returned.
 func (s *SyncerClient) SupportsNodeResourceUpdates(timeout time.Duration) (bool, error) {
-	// If we've already gotten a MsgServerHello just return with the value
+	// If a previous call has already marked the handshake as complete, then just return the value.
 	if s.handshakeStatus.complete {
 		return s.supportsNodeResourceUpdates, nil
 	}

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -214,6 +214,9 @@ type MsgServerHello struct {
 	// SyncerType the active syncer type; if not specified, implies that the server is an older Typha instance that
 	// only supports SyncerTypeFelix.
 	SyncerType SyncerType
+
+	// SupportsNodeResourceUpdates specifies whether this Typha supports node resource updates.
+	SupportsNodeResourceUpdates bool
 }
 type MsgSyncStatus struct {
 	SyncStatus api.SyncStatus

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -215,7 +215,7 @@ type MsgServerHello struct {
 	// only supports SyncerTypeFelix.
 	SyncerType SyncerType
 
-	// SupportsNodeResourceUpdates specifies whether this Typha supports node resource updates.
+	// SupportsNodeResourceUpdates provides to the client whether this Typha supports node resource updates.
 	SupportsNodeResourceUpdates bool
 }
 type MsgSyncStatus struct {

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -673,7 +673,8 @@ func (h *connection) doHandshake() error {
 		Version: buildinfo.GitVersion,
 		// Echo back the SyncerType so that up-level clients know that we understood their request.  Down-level
 		// clients will ignore.
-		SyncerType: syncerType,
+		SyncerType:                  syncerType,
+		SupportsNodeResourceUpdates: true,
 	})
 	if err != nil {
 		log.WithError(err).Warning("Failed to send hello to client")


### PR DESCRIPTION
## Description

This is a follow-on PR to recent work to add VXLAN cross-subnet support. One of those PRs added a full node object to the Felix update processor: https://github.com/projectcalico/libcalico-go/pull/1115 

This PR allows Typha clients to know whether the Typha server supports node resource updates (by being compiled with a libcalico-go that includes it). If the Typha server does not support node resource updates and VXLAN cross-subnet is configured, then Felix will proceed as if VXLAN "always" was configured.

Once this is merged, a corresponding change to Felix is required in the case where Typha is enabled:
- After the Typha connection is created, call `typhaConnection.SupportsNodeResourceUpdates`
- Use the response to update config params that are eventually used to [configure](https://github.com/projectcalico/felix/blob/master/calc/vxlan_resolver.go#L86) the VXLAN resolver.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
