### PR TITLE
Ensure appending to PUSH_IMAGES is not part of a recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 PACKAGE_NAME?=github.com/projectcalico/typha
 GO_BUILD_VER=v0.31
 
+# This needs to be evaluated before the common makefile is included.
+# This var contains some default values that the common makefile may append to.
+PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/cni
+
 ###############################################################################
 # Download and include Makefile.common
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
@@ -33,8 +37,6 @@ include Makefile.common
 ###############################################################################
 
 BUILD_IMAGE=calico/typha
-
-PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/typha
 RELEASE_IMAGES?=gcr.io/projectcalico-org/typha eu.gcr.io/projectcalico-org/typha asia.gcr.io/projectcalico-org/typha us.gcr.io/projectcalico-org/typha
 
 # Linker flags for building Typha.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME?=github.com/projectcalico/typha
-GO_BUILD_VER=v0.31
+GO_BUILD_VER=v0.34
 
 # This needs to be evaluated before the common makefile is included.
 # This var contains some default values that the common makefile may append to.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO_BUILD_VER=v0.34
 
 # This needs to be evaluated before the common makefile is included.
 # This var contains some default values that the common makefile may append to.
-PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/cni
+PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/typha
 
 ###############################################################################
 # Download and include Makefile.common


### PR DESCRIPTION
## Description
The invocation make tag-images-all RELEASE=true IMAGETAG=<tag> was not tagging and pushing the image to gcr.io registries.

This PR addresses part of that: the PUSH_IMAGES variable needs to be defined before Makefile.common is included, otherwise PUSH_IMAGES will lose its initial default values. The second part is fixed in the common Makefile in projectcalico/go-build#95
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
