### PR TITLE
Don't List nodes, watch them!

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect
 	gopkg.in/go-playground/validator.v9 v9.28.0 // indirect
 	gopkg.in/ini.v1 v1.44.0 // indirect
+	k8s.io/api v0.0.0-20191114100352-16d7abae0d2a
 
 	// k8s.io/apimachinery 1.16.3 is at 72ed19daf4bb
 	k8s.io/apimachinery v0.0.0-20191028221656-72ed19daf4bb

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect
 	gopkg.in/go-playground/validator.v9 v9.28.0 // indirect
 	gopkg.in/ini.v1 v1.44.0 // indirect
-	k8s.io/api v0.0.0-20191114100352-16d7abae0d2a
 
 	// k8s.io/apimachinery 1.16.3 is at 72ed19daf4bb
 	k8s.io/apimachinery v0.0.0-20191028221656-72ed19daf4bb

--- a/pkg/calc/node_counter.go
+++ b/pkg/calc/node_counter.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package calc
+
+import (
+	"fmt"
+	"sync"
+
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	"github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+)
+
+func NewNodeCounter(sink api.SyncerCallbacks) *NodeCounter {
+	return &NodeCounter{
+		sink:    sink,
+		nodeMap: map[string]bool{},
+	}
+}
+
+type NodeCounter struct {
+	sync.Mutex
+	sink    api.SyncerCallbacks
+	inSync  bool
+	nodeMap map[string]bool
+}
+
+func (c *NodeCounter) OnStatusUpdated(status api.SyncStatus) {
+	if status == api.InSync {
+		c.Lock()
+		c.inSync = true
+		c.Unlock()
+	}
+	c.sink.OnStatusUpdated(status)
+}
+
+func (c *NodeCounter) OnUpdates(updates []api.Update) {
+	for _, update := range updates {
+		switch k := update.Key.(type) {
+		case model.ResourceKey:
+			if k.Kind == v3.KindNode {
+				name := k.Name
+				switch update.UpdateType {
+				case api.UpdateTypeKVNew:
+					c.setNode(name)
+				case api.UpdateTypeKVDeleted:
+					c.deleteNode(name)
+				}
+			}
+		}
+	}
+	c.sink.OnUpdates(updates)
+}
+
+func (c *NodeCounter) GetNumNodes() (int, error) {
+	c.Lock()
+	defer c.Unlock()
+	if !c.inSync {
+		return 0, fmt.Errorf("Node counter not yet in sync")
+	}
+	return len(c.nodeMap), nil
+}
+
+func (c *NodeCounter) setNode(node string) {
+	c.Lock()
+	defer c.Unlock()
+	c.nodeMap[node] = true
+}
+
+func (c *NodeCounter) deleteNode(node string) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.nodeMap, node)
+}

--- a/pkg/k8s/lookup.go
+++ b/pkg/k8s/lookup.go
@@ -15,27 +15,22 @@
 package k8s
 
 import (
-	"fmt"
-
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/projectcalico/libcalico-go/lib/set"
+	"github.com/projectcalico/typha/pkg/calc"
 )
 
-func NewK8sAPI() *RealK8sAPI {
-	return &RealK8sAPI{}
+func NewK8sAPI(nc *calc.NodeCounter) *RealK8sAPI {
+	return &RealK8sAPI{nodeCounter: nc}
 }
 
 type RealK8sAPI struct {
-	cachedClientSet    *kubernetes.Clientset
-	cachedNodeIndexer  cache.Indexer
-	cachedNodeInformer cache.Controller
+	cachedClientSet *kubernetes.Clientset
+	nodeCounter     *calc.NodeCounter
 }
 
 func (r *RealK8sAPI) clientSet() (*kubernetes.Clientset, error) {
@@ -54,28 +49,6 @@ func (r *RealK8sAPI) clientSet() (*kubernetes.Clientset, error) {
 		r.cachedClientSet = clientSet
 	}
 	return r.cachedClientSet, nil
-}
-
-func (r *RealK8sAPI) nodeIndexer() (cache.Indexer, error) {
-	if r.cachedNodeIndexer == nil {
-		// Create an indexer for nodes that we can use to access resource counts without
-		// going all the way to the API.
-		clientSet, err := r.clientSet()
-		if err != nil {
-			return nil, err
-		}
-
-		nodeListWatcher := cache.NewListWatchFromClient(clientSet.CoreV1().RESTClient(), "nodes", metav1.NamespaceNone, fields.Everything())
-		nodeIndexer, nodeInformer := cache.NewIndexerInformer(nodeListWatcher, &v1.Node{}, 0, cache.ResourceEventHandlerFuncs{}, cache.Indexers{})
-		r.cachedNodeIndexer = nodeIndexer
-		r.cachedNodeInformer = nodeInformer
-	}
-
-	// If the informer hasn't synced yet, return an error. We'll retry later.
-	if !r.cachedNodeInformer.HasSynced() {
-		return nil, fmt.Errorf("Node informer has not yet sync'd")
-	}
-	return r.cachedNodeIndexer, nil
 }
 
 func (r *RealK8sAPI) GetNumTyphas(namespace, serviceName, portName string) (int, error) {
@@ -109,10 +82,5 @@ func (r *RealK8sAPI) GetNumTyphas(namespace, serviceName, portName string) (int,
 }
 
 func (r *RealK8sAPI) GetNumNodes() (int, error) {
-	// Use the indexer's local store to get the number of nodes.
-	indexer, err := r.nodeIndexer()
-	if err != nil {
-		return 0, err
-	}
-	return len(indexer.ListKeys()), nil
+	return r.nodeCounter.GetNumNodes()
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Typha is already watching Node objects through the Syncer so drive it off that!

I also haven't optimized the Get() for the Endpoints object used to determine the number of Typhas - maybe we should, but it should be a really low-traffic call and I wouldn't expect it to have performance impact. 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Typha no longer uses Get requests to determine the number of nodes in the cluster, using watches instead. 
```