### PR TITLE
Apply typha defaults before loading config

### DIFF
--- a/pkg/syncclientutils/config.go
+++ b/pkg/syncclientutils/config.go
@@ -28,9 +28,13 @@ import (
 type TyphaConfig struct {
 	Addr           string
 	K8sServiceName string
-	K8sNamespace   string
-	ReadTimeout    time.Duration
-	WriteTimeout   time.Duration
+
+	// This is defaulted to "kube-system" if not explicitly specified.
+	K8sNamespace string
+
+	// These are defaulted in the typha sync-client if not specified.
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
 
 	// Client-side TLS config for communication with Typha.  If any of these are
 	// specified, they _all_ must be - except that either CN or URISAN may be left unset.
@@ -49,7 +53,10 @@ type TyphaConfig struct {
 // The supportedPrefixes is the set of allowed prefixes for each environment name. Name format is therefore:
 // <prefix>TYPHA<fieldname uppercase>,  e.g.  CONFD_TYPHAADDR
 func ReadTyphaConfig(supportedPrefixes []string) TyphaConfig {
-	typhaConfig := &TyphaConfig{}
+	typhaConfig := &TyphaConfig{
+		// Apply defaults before loading the config.
+		K8sNamespace: "kube-system",
+	}
 	kind := reflect.TypeOf(*typhaConfig)
 	for ii := 0; ii < kind.NumField(); ii++ {
 		field := kind.Field(ii)


### PR DESCRIPTION
## Description
There was a little bit I'd missed copying the code from confd that I think we can put here rather than need to default in the calling code.

		Typha: TyphaConfig{
			// Non-zero defaults copied from <felix>/config/config_params.go.
			K8sNamespace: "kube-system",
			ReadTimeout:  30 * time.Second,
			WriteTimeout: 10 * time.Second,
		},

https://github.com/projectcalico/confd/blob/master/pkg/config/config.go#L94


## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
