### PR TITLE
Respect new libcalico-go datastore type defaulting behaviour.

### DIFF
--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -298,9 +298,8 @@ func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
 	if err != nil {
 		log.WithError(err).Panic("Failed to create datastore config")
 	}
-	// If that didn't set the datastore type (in which case the field will have been set to its
-	// default 'etcdv3' value), copy it from the Felix config.
-	if cfg.Spec.DatastoreType == "etcdv3" {
+	// If that didn't set the datastore type, use our config parameter.
+	if cfg.Spec.DatastoreType == "" {
 		cfg.Spec.DatastoreType = apiconfig.DatastoreType(config.DatastoreType)
 	}
 	return *cfg


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
It now returns "" instead of "etcdv3" if it doesn't find its expected environment variable.

This quick fix should restore the old behaviour but we may want to clean this up further.  Shouldn't libcalico-go set the default?

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
