### PR TITLE
Rev libcalico-go and remove datastore defaulting.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mipearson/rfw v0.0.0-20170619235010-6f0a6f3266ba
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
-	github.com/projectcalico/libcalico-go v1.7.2-0.20200910175914-28120f09b019
+	github.com/projectcalico/libcalico-go v1.7.2-0.20200914122856-2f9fd819a698
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mipearson/rfw v0.0.0-20170619235010-6f0a6f3266ba
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
-	github.com/projectcalico/libcalico-go v1.7.2-0.20200914122856-2f9fd819a698
+	github.com/projectcalico/libcalico-go v1.7.2-0.20200914144038-956cc91d8a15
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba h1:aaF2byUCZ
 github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba/go.mod h1:q8EdCgBdMQzgiX/uk4GXLWLk+gIHd1a7mWUAamJKDb4=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:Jt2Pic9dxgJisekm8q2WV9FaWxUJhhRfwHSP640drww=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
-github.com/projectcalico/libcalico-go v1.7.2-0.20200910175914-28120f09b019 h1:mZHKsGxzmaaUZKPp538b0KCmzCergpo5mLlsDM5UJUk=
-github.com/projectcalico/libcalico-go v1.7.2-0.20200910175914-28120f09b019/go.mod h1:+HQmSvCZc2MCvkgOm1tn0zAkpJikDhvhcRcAiavLYtg=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200914122856-2f9fd819a698 h1:sVFJbe5AN3mDGdId8pH5gd3Dw724utQiBrcRs71F3jk=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200914122856-2f9fd819a698/go.mod h1:+HQmSvCZc2MCvkgOm1tn0zAkpJikDhvhcRcAiavLYtg=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
 github.com/prometheus/client_golang v0.9.1 h1:K47Rk0v/fkEfwfQet2KWhscE0cJzjgCCDBG2KHZoVno=

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba h1:aaF2byUCZ
 github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba/go.mod h1:q8EdCgBdMQzgiX/uk4GXLWLk+gIHd1a7mWUAamJKDb4=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:Jt2Pic9dxgJisekm8q2WV9FaWxUJhhRfwHSP640drww=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
-github.com/projectcalico/libcalico-go v1.7.2-0.20200914122856-2f9fd819a698 h1:sVFJbe5AN3mDGdId8pH5gd3Dw724utQiBrcRs71F3jk=
-github.com/projectcalico/libcalico-go v1.7.2-0.20200914122856-2f9fd819a698/go.mod h1:+HQmSvCZc2MCvkgOm1tn0zAkpJikDhvhcRcAiavLYtg=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200914144038-956cc91d8a15 h1:cvLf/xrqHmVriZaKZMC/GY8UVzyPcNqPrW/PR13yCzc=
+github.com/projectcalico/libcalico-go v1.7.2-0.20200914144038-956cc91d8a15/go.mod h1:+HQmSvCZc2MCvkgOm1tn0zAkpJikDhvhcRcAiavLYtg=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
 github.com/prometheus/client_golang v0.9.1 h1:K47Rk0v/fkEfwfQet2KWhscE0cJzjgCCDBG2KHZoVno=

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -264,10 +264,10 @@ func (config *Config) resolve() (changed bool, err error) {
 }
 
 func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
-	// Special case for etcdv3 datastore, where we want to honour established Felix-specific
+	// Special case for etcdv3 datastore, where we want to honour established
 	// config mechanisms.
 	if config.DatastoreType == "etcdv3" {
-		// Build a CalicoAPIConfig with the etcd fields filled in from Felix-specific
+		// Build a CalicoAPIConfig with the etcd fields filled in from our config.
 		// config.
 		var etcdEndpoints string
 		if len(config.EtcdEndpoints) == 0 {
@@ -289,18 +289,11 @@ func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
 		}
 	}
 
-	// Build CalicoAPIConfig from the environment.  This means that any XxxYyy field in
-	// CalicoAPIConfigSpec can be set by a corresponding XXX_YYY or CALICO_XXX_YYY environment
-	// variable, and that the datastore type can be set by a DATASTORE_TYPE or
-	// CALICO_DATASTORE_TYPE variable.  (Except in the etcdv3 case which is handled specially
-	// above.)
+	// Kubernetes mode, which is now the default for LoadClientConfigFromEnvironment so we let
+	// it do it's thing...
 	cfg, err := apiconfig.LoadClientConfigFromEnvironment()
 	if err != nil {
 		log.WithError(err).Panic("Failed to create datastore config")
-	}
-	// If that didn't set the datastore type, use our config parameter.
-	if cfg.Spec.DatastoreType == "" {
-		cfg.Spec.DatastoreType = apiconfig.DatastoreType(config.DatastoreType)
 	}
 	return *cfg
 }

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -290,7 +290,7 @@ func (config *Config) DatastoreConfig() apiconfig.CalicoAPIConfig {
 	}
 
 	// Kubernetes mode, which is now the default for LoadClientConfigFromEnvironment so we let
-	// it do it's thing...
+	// it do its thing...
 	cfg, err := apiconfig.LoadClientConfigFromEnvironment()
 	if err != nil {
 		log.WithError(err).Panic("Failed to create datastore config")


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
libcalico-go now defaults to kubernetes mode so, either we handle the datastore in the `config.DatastoreType == etcdv3` branch or LoadClientConfigFromEnvironment will do the right thing.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
