### PR TITLE
Fix v3 resource deduplication.

### DIFF
--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -119,7 +120,11 @@ var (
 	v3Node = api.Update{
 		KVPair: model.KVPair{
 			Key:      model.ResourceKey{Name: "node1", Kind: v3.KindNode},
-			Value:    &v3.Node{},
+			Value:    &v3.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1237",
+				},
+			},
 			Revision: "1237",
 		},
 		UpdateType: api.UpdateTypeKVNew,
@@ -127,7 +132,11 @@ var (
 	v3BGPPeer = api.Update{
 		KVPair: model.KVPair{
 			Key:      model.ResourceKey{Name: "peer1", Kind: v3.KindBGPPeer},
-			Value:    &v3.BGPPeer{},
+			Value:    &v3.BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1238",
+				},
+			},
 			Revision: "1238",
 		},
 		UpdateType: api.UpdateTypeKVNew,

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -266,7 +266,9 @@ func SerializeUpdate(u api.Update) (su SerializedUpdate, err error) {
 		// should always be the same as the internal revision but we copy it over just to make
 		// sure that we replace the revision correctly on the client side.
 		log.Debug("v3 resource, zeroing its internal resource version for dedupe.")
-		su.Revision = obj.GetResourceVersion()
+		version := obj.GetResourceVersion()
+		su.Revision = version
+		defer obj.SetResourceVersion(version) // Restore the input object, mainly for UT.
 		obj.SetResourceVersion("")
 	}
 

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -261,7 +261,7 @@ func SerializeUpdate(u api.Update) (su SerializedUpdate, err error) {
 		log.Debug("Value is nil, passing through as a deletion.")
 		return
 	} else if obj, ok := u.Value.(v1.Object); ok {
-		// Since v3 object carry their resource version inside their internal metadata, our
+		// Since v3 objectsgit commi carry their resource version inside their internal metadata, our
 		// later dedupe comparison will always fail unless we zero this out. The KVP revision
 		// should always be the same as the internal revision but we copy it over just to make
 		// sure that we replace the revision correctly on the client side.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Since the v3 resources have an embedded resource version, dedupe was always
failing.

May fix https://github.com/projectcalico/calico/issues/4129

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
