### PR TITLE
[v3.16] Backport v3 resource deduplication fix

### DIFF
--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -29,6 +29,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -119,7 +120,11 @@ var (
 	v3Node = api.Update{
 		KVPair: model.KVPair{
 			Key:      model.ResourceKey{Name: "node1", Kind: v3.KindNode},
-			Value:    &v3.Node{},
+			Value:    &v3.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1237",
+				},
+			},
 			Revision: "1237",
 		},
 		UpdateType: api.UpdateTypeKVNew,
@@ -127,7 +132,11 @@ var (
 	v3BGPPeer = api.Update{
 		KVPair: model.KVPair{
 			Key:      model.ResourceKey{Name: "peer1", Kind: v3.KindBGPPeer},
-			Value:    &v3.BGPPeer{},
+			Value:    &v3.BGPPeer{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "1238",
+				},
+			},
 			Revision: "1238",
 		},
 		UpdateType: api.UpdateTypeKVNew,

--- a/pkg/syncproto/sync_proto.go
+++ b/pkg/syncproto/sync_proto.go
@@ -165,6 +165,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
@@ -259,6 +260,15 @@ func SerializeUpdate(u api.Update) (su SerializedUpdate, err error) {
 	if u.Value == nil {
 		log.Debug("Value is nil, passing through as a deletion.")
 		return
+	} else if obj, ok := u.Value.(v1.Object); ok {
+		// Since Calico v3 objects carry their resource version inside their internal metadata, our
+		// later dedupe comparison will always fail.  To counter that, we move the resource version
+		// to a field of the SerializedUpdate before we serialize.
+		log.Debug("v3 resource, zeroing its internal resource version for dedupe.")
+		version := obj.GetResourceVersion()
+		su.V3ResourceVersion = version
+		defer obj.SetResourceVersion(version) // Restore the input object, mainly for UT.
+		obj.SetResourceVersion("")
 	}
 
 	value, err := model.SerializeValue(&u.KVPair)
@@ -274,11 +284,12 @@ func SerializeUpdate(u api.Update) (su SerializedUpdate, err error) {
 }
 
 type SerializedUpdate struct {
-	Key        string
-	Value      []byte
-	Revision   interface{}
-	TTL        time.Duration
-	UpdateType api.UpdateType
+	Key               string
+	Value             []byte
+	Revision          interface{}
+	V3ResourceVersion string
+	TTL               time.Duration
+	UpdateType        api.UpdateType
 }
 
 var ErrBadKey = errors.New("Unable to parse key.")
@@ -297,6 +308,11 @@ func (s SerializedUpdate) ToUpdate() (api.Update, error) {
 		if err != nil {
 			log.WithField("rawValue", string(s.Value)).Error(
 				"Failed to parse value.")
+		} else {
+			if obj, ok := parsedValue.(v1.Object); ok {
+				log.Debug("v3 resource, populating its internal resource version.")
+				obj.SetResourceVersion(fmt.Sprint(s.V3ResourceVersion))
+			}
 		}
 	}
 	revStr := ""
@@ -319,10 +335,12 @@ func (s SerializedUpdate) ToUpdate() (api.Update, error) {
 
 // WouldBeNoOp returns true if this update would be a no-op given that previous has already been sent.
 func (s SerializedUpdate) WouldBeNoOp(previous SerializedUpdate) bool {
-	// We don't care if the revision has changed so nil it out.  Note: we're using the fact that this is a
+	// We don't care if the revision(s) have changed so zero them out.  Note: we're using the fact that this is a
 	// value type so these changes won't be propagated to the caller!
 	s.Revision = nil
+	s.V3ResourceVersion = ""
 	previous.Revision = nil
+	previous.V3ResourceVersion = ""
 
 	if previous.UpdateType == api.UpdateTypeKVNew {
 		// If the old update was a create, convert it to an update before the comparison since it's OK to
@@ -330,7 +348,6 @@ func (s SerializedUpdate) WouldBeNoOp(previous SerializedUpdate) bool {
 		previous.UpdateType = api.UpdateTypeKVUpdated
 	}
 
-	// TODO Typha Add UT to make sure that the serialization is always the same (current JSON impl does make that guarantee)
 	return reflect.DeepEqual(s, previous)
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Backport #449 

Fix v3 resource deduplication.

(cherry picked from commit 2ecea02454e8f22b8844d1b3b50e30001b4b451d)
## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that Typha was unable to deduplicate Calico v3 Node resources.  This caused excessive CPU usage in Felix.
```
