### PR TITLE
[v3.17] Backport: Move kubernetes discovery to Typha so it can be shared.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .go-pkg-cache/
 /.glide/
 /vendor/
+pkg/report
 
 # IDE files.
 /.idea/

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 // indirect
 	gopkg.in/go-playground/validator.v9 v9.28.0 // indirect
 	gopkg.in/ini.v1 v1.44.0 // indirect
+	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2
 )

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/projectcalico/libcalico-go/lib/set"
+)
+
+var ErrServiceNotReady = errors.New("Kubernetes service missing IP or port")
+
+type options struct {
+	addrOverride string
+
+	k8sClient          kubernetes.Interface
+	k8sServiceName     string
+	k8sNamespace       string
+	k8sServicePortName string
+	inCluster          bool
+}
+
+type Option func(opts *options)
+
+func WithAddrOverride(addr string) Option {
+	return func(opts *options) {
+		opts.addrOverride = addr
+	}
+}
+
+func WithKubeClient(client kubernetes.Interface) Option {
+	return func(opts *options) {
+		opts.k8sClient = client
+	}
+}
+
+// WithInClusterKubeClient enables auto-connection to Kubernetes using the in-cluster client config.
+// this is disabled by default to avoid creating an extra Kubernetes client that is then discarded.
+func WithInClusterKubeClient() Option {
+	return func(opts *options) {
+		opts.inCluster = true
+	}
+}
+
+func WithKubeService(namespaceName, serviceName string) Option {
+	return func(opts *options) {
+		opts.k8sNamespace = namespaceName
+		opts.k8sServiceName = serviceName
+	}
+}
+
+func WithKubeServicePortNameOverride(portName string) Option {
+	return func(opts *options) {
+		opts.k8sServicePortName = portName
+	}
+}
+
+// DiscoverTyphaAddr tries to discover the best address to use to connect to Typha.
+//
+// If an AddrOverride is supplied then that takes precedence, otherwise, DiscoverTyphaAddr will
+// try to lookup one of the backend endpoints of the typha service (using the K8sServiceName and
+// K8sNamespace fields).
+//
+// Returns "" if typha is not enabled (i.e. fields are empty).
+func DiscoverTyphaAddr(opts ...Option) (string, error) {
+	options := options{
+		k8sServicePortName: "calico-typha",
+	}
+
+	for _, o := range opts {
+		o(&options)
+	}
+
+	if options.addrOverride != "" {
+		// Explicit address; trumps other sources of config.
+		return options.addrOverride, nil
+	}
+
+	if options.k8sServiceName == "" {
+		// No explicit address, and no service name, not using Typha.
+		return "", nil
+	}
+
+	// If we get here, we need to look up the Typha service using the k8s API.
+	if options.k8sClient == nil && options.inCluster {
+		// Client didn't provide a kube client but we're allowed to create one.
+		k8sConf, err := rest.InClusterConfig()
+		if err != nil {
+			logrus.WithError(err).Error("Unable to create in-cluster Kubernetes config.")
+			return "", err
+		}
+		options.k8sClient, err = kubernetes.NewForConfig(k8sConf)
+		if err != nil {
+			logrus.WithError(err).Error("Unable to create Kubernetes client set.")
+			return "", err
+		}
+	} else if options.k8sClient == nil {
+		return "", errors.New("failed to look up Typha, no Kubernetes client available")
+	}
+
+	// If we get here, we need to look up the Typha service endpoints using the k8s API.
+	epClient := options.k8sClient.CoreV1().Endpoints(options.k8sNamespace)
+	eps, err := epClient.Get(options.k8sServiceName, v1.GetOptions{})
+	if err != nil {
+		logrus.WithError(err).Error("Unable to get Typha service endpoints from Kubernetes.")
+		return "", err
+	}
+
+	candidates := set.New()
+
+	for _, subset := range eps.Subsets {
+		var portForOurVersion int32
+		for _, port := range subset.Ports {
+			if port.Name == options.k8sServicePortName {
+				portForOurVersion = port.Port
+				break
+			}
+		}
+
+		if portForOurVersion == 0 {
+			continue
+		}
+
+		// If we get here, this endpoint supports the typha port we're looking for.
+		for _, h := range subset.Addresses {
+			typhaAddr := net.JoinHostPort(h.IP, fmt.Sprint(portForOurVersion))
+			candidates.Add(typhaAddr)
+		}
+	}
+
+	if candidates.Len() == 0 {
+		logrus.Error("Didn't find any ready Typha instances.")
+		return "", ErrServiceNotReady
+	}
+
+	var addrs []string
+	candidates.Iter(func(item interface{}) error {
+		typhaAddr := item.(string)
+		addrs = append(addrs, typhaAddr)
+		return nil
+	})
+	logrus.WithField("addrs", addrs).Info("Found ready Typha addresses.")
+	n := rand.Intn(len(addrs))
+	chosenAddr := addrs[n]
+	logrus.WithField("choice", chosenAddr).Info("Chose Typha to connect to.")
+
+	return chosenAddr, nil
+}

--- a/pkg/discovery/discovery_suite_test.go
+++ b/pkg/discovery/discovery_suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017-2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+
+	"github.com/onsi/ginkgo/reporters"
+
+	"github.com/projectcalico/libcalico-go/lib/testutils"
+)
+
+func init() {
+	testutils.HookLogrusForGinkgo()
+}
+
+func TestDiscovery(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("../../report/discovery_suite.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Discovery Suite", []Reporter{junitReporter})
+}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2019-2020 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package discovery
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/projectcalico/libcalico-go/lib/set"
+)
+
+var _ = Describe("Typha address discovery", func() {
+	var (
+		endpoints *v1.Endpoints
+		k8sClient *fake.Clientset
+	)
+
+	refreshClient := func() {
+		k8sClient = fake.NewSimpleClientset(endpoints)
+	}
+
+	BeforeEach(func() {
+		rand.Seed(time.Now().UTC().UnixNano())
+		endpoints = &v1.Endpoints{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Endpoints",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "calico-typha-service",
+				Namespace: "kube-system",
+			},
+			Subsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{IP: "10.0.0.4"},
+					},
+					NotReadyAddresses: []v1.EndpointAddress{},
+					Ports: []v1.EndpointPort{
+						{Name: "calico-typha-v2", Port: 8157, Protocol: v1.ProtocolUDP},
+					},
+				},
+				{
+					Addresses: []v1.EndpointAddress{
+						{IP: "10.0.0.2"},
+					},
+					NotReadyAddresses: []v1.EndpointAddress{
+						{IP: "10.0.0.5"},
+					},
+					Ports: []v1.EndpointPort{
+						{Name: "calico-typha-v2", Port: 8157, Protocol: v1.ProtocolUDP},
+						{Name: "calico-typha", Port: 8156, Protocol: v1.ProtocolTCP},
+					},
+				},
+			},
+		}
+
+		refreshClient()
+	})
+
+	It("should return address if configured", func() {
+		typhaAddr, err := DiscoverTyphaAddr(WithAddrOverride("10.0.0.1:8080"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(Equal("10.0.0.1:8080"))
+	})
+
+	It("should return nothing if no service name and no client", func() {
+		typhaAddr, err := DiscoverTyphaAddr()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(Equal(""))
+	})
+
+	It("should return nothing if no service name with client", func() {
+		typhaAddr, err := DiscoverTyphaAddr(WithKubeClient(k8sClient))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(Equal(""))
+	})
+
+	It("should return IP from endpoints", func() {
+		typhaAddr, err := DiscoverTyphaAddr(
+			WithKubeService("kube-system", "calico-typha-service"),
+			WithKubeClient(k8sClient),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(Equal("10.0.0.2:8156"))
+	})
+
+	It("should return v2 IP from endpoints if port name override is used", func() {
+		typhaAddr, err := DiscoverTyphaAddr(
+			WithKubeService("kube-system", "calico-typha-service"),
+			WithKubeClient(k8sClient),
+			WithKubeServicePortNameOverride("calico-typha-v2"),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(Or(Equal("10.0.0.4:8157"), Equal("10.0.0.2:8157")))
+	})
+
+	It("should bracket an IPv6 Typha address", func() {
+		endpoints.Subsets[1].Addresses[0].IP = "fd5f:65af::2"
+		refreshClient()
+		typhaAddr, err := DiscoverTyphaAddr(
+			WithKubeService("kube-system", "calico-typha-service"),
+			WithKubeClient(k8sClient),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typhaAddr).To(Equal("[fd5f:65af::2]:8156"))
+	})
+
+	It("should error if no Typhas", func() {
+		endpoints.Subsets = nil
+		refreshClient()
+		_, err := DiscoverTyphaAddr(
+			WithKubeService("kube-system", "calico-typha-service"),
+			WithKubeClient(k8sClient),
+		)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should choose random Typhas", func() {
+		seenAddresses := set.New()
+		expected := set.From("10.0.0.2:8156", "10.0.0.6:8156")
+		endpoints.Subsets[1].Addresses = append(endpoints.Subsets[1].Addresses, v1.EndpointAddress{IP: "10.0.0.6"})
+		refreshClient()
+
+		for i := 0; i < 32; i++ {
+			addr, err := DiscoverTyphaAddr(
+				WithKubeService("kube-system", "calico-typha-service"),
+				WithKubeClient(k8sClient),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			seenAddresses.Add(addr)
+			if seenAddresses.ContainsAll(expected) {
+				return
+			}
+		}
+		Fail(fmt.Sprintf("Didn't get expected values; got %v", seenAddresses))
+	})
+})

--- a/pkg/syncclientutils/startsyncerclient.go
+++ b/pkg/syncclientutils/startsyncerclient.go
@@ -16,17 +16,12 @@ package syncclientutils
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"net"
-
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	log "github.com/sirupsen/logrus"
 
 	"github.com/projectcalico/libcalico-go/lib/backend/api"
+
+	"github.com/projectcalico/typha/pkg/discovery"
 	"github.com/projectcalico/typha/pkg/syncclient"
 	"github.com/projectcalico/typha/pkg/syncproto"
 )
@@ -38,11 +33,17 @@ import (
 //
 // The typha address may be directly configured in the typha config, or will otherwise be looked by finding the
 // associated Kubernetes service.
-func MustStartSyncerClientIfTyphaConfigured(typhaConfig *TyphaConfig, syncerType syncproto.SyncerType,
+func MustStartSyncerClientIfTyphaConfigured(
+	typhaConfig *TyphaConfig,
+	syncerType syncproto.SyncerType,
 	myVersion, myHostname, myInfo string,
 	cbs api.SyncerCallbacks,
 ) bool {
-	typhaAddr, err := discoverTyphaAddr(typhaConfig)
+	typhaAddr, err := discovery.DiscoverTyphaAddr(
+		discovery.WithAddrOverride(typhaConfig.Addr),
+		discovery.WithInClusterKubeClient(), /* defer creation of a client until its needed. */
+		discovery.WithKubeService(typhaConfig.K8sNamespace, typhaConfig.K8sServiceName),
+	)
 	if err != nil {
 		log.WithError(err).Fatal("Typha discovery enabled but discovery failed.")
 	}
@@ -77,56 +78,4 @@ func MustStartSyncerClientIfTyphaConfigured(typhaConfig *TyphaConfig, syncerType
 	}()
 
 	return true
-}
-
-var ErrServiceNotReady = errors.New("Kubernetes service missing IP or port.")
-
-// discoverTyphaAddr attempts to discover the typha kubernetes service.
-// -  If an address is explicitly specified, return that
-// -  If a kubernetes service name is specified then use that to look up the service
-// -  Otherwise, assume typha is not configured and return an empty addr string.
-func discoverTyphaAddr(typhaConfig *TyphaConfig) (string, error) {
-	if typhaConfig.Addr != "" {
-		// Explicit address; trumps other sources of config.
-		return typhaConfig.Addr, nil
-	}
-
-	if typhaConfig.K8sServiceName == "" {
-		// No explicit address, and no service name, not using Typha.
-		return "", nil
-	}
-
-	// If we get here, we need to look up the Typha service using the k8s API.
-	// TODO Typha: support Typha lookup without using rest.InClusterConfig().
-	k8sconf, err := rest.InClusterConfig()
-	if err != nil {
-		log.WithError(err).Error("Unable to create Kubernetes config.")
-		return "", err
-	}
-	clientset, err := kubernetes.NewForConfig(k8sconf)
-	if err != nil {
-		log.WithError(err).Error("Unable to create Kubernetes client set.")
-		return "", err
-	}
-	svcClient := clientset.CoreV1().Services(typhaConfig.K8sNamespace)
-	svc, err := svcClient.Get(typhaConfig.K8sServiceName, v1.GetOptions{})
-	if err != nil {
-		log.WithError(err).Error("Unable to get Typha service from Kubernetes.")
-		return "", err
-	}
-	host := svc.Spec.ClusterIP
-	log.WithField("clusterIP", host).Info("Found Typha ClusterIP.")
-	if host == "" {
-		log.WithError(err).Error("Typha service had no ClusterIP.")
-		return "", ErrServiceNotReady
-	}
-	for _, p := range svc.Spec.Ports {
-		if p.Name == "calico-typha" {
-			log.WithField("port", p).Info("Found Typha service port.")
-			typhaAddr := net.JoinHostPort(host, fmt.Sprintf("%v", p.Port))
-			return typhaAddr, nil
-		}
-	}
-	log.Error("Didn't find Typha service port.")
-	return "", ErrServiceNotReady
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Backport of #462  #463  #464 

(cherry picked from commit 71903c810b3d31cbd47f7a2b9bf7815ac51a453d)
(cherry picked from commit de365c2dc753a6ac8d11176179709708b040fbbf)
(cherry picked from commit ff204c3515d51d3f7572c9cd0e0b5858e9210cd8)
(cherry picked from commit 04f6aec37b10de20d53278c71928c7487c08f0d8)

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
All components that use Typha now use the same logic to discover Typha's address.  They lookup the endpoints of the service directly and connect to one at random.  This avoids a dependency on kube-proxy.
```
