### PR TITLE
[v3.16] Backport Semaphore v2 builds

### DIFF
--- a/.semaphore/clear_cache.yml
+++ b/.semaphore/clear_cache.yml
@@ -1,0 +1,25 @@
+version: v1.0
+name: Typha
+
+execution_time_limit:
+  hours: 2
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+global_job_config:
+  secrets:
+  - name: docker-hub
+  prologue:
+    commands:
+    - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+
+blocks:
+  - name: 'Clear Cache'
+    task:
+      jobs:
+        - name: Clear Cache
+          commands:
+            - 'cache clear'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,109 @@
+version: v1.0
+name: Typha
+
+execution_time_limit:
+  hours: 2
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+global_job_config:
+  secrets:
+  - name: docker-hub
+  prologue:
+    commands:
+      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      - checkout
+      # Note that the 'cache restore' commands require that the "Build" block has been run. The "Build" block is what populates
+      # the cache, therefore every block that requires the use of these cached items must make the "Build" block one of
+      # it's dependencies.
+      - 'cache restore go-pkg-cache-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore go-mod-cache-${SEMAPHORE_GIT_SHA}'
+      - 'cache restore bin-${SEMAPHORE_GIT_SHA}'
+
+blocks:
+  - name: 'Build'
+    dependencies: []
+    task:
+      jobs:
+        - name: Build
+          commands:
+            - make build
+            - 'cache store bin-${SEMAPHORE_GIT_SHA} bin'
+            - 'cache store go-pkg-cache-${SEMAPHORE_GIT_SHA} .go-pkg-cache'
+            - 'cache store go-mod-cache-${SEMAPHORE_GIT_SHA} ${HOME}/go/pkg/mod/cache'
+
+  - name: 'UTs'
+    dependencies: ["Build"]
+    task:
+      jobs:
+        - name: Run UT
+          commands:
+            - make ci EXCEPT=k8sfv-test
+
+  - name: 'FVs'
+    dependencies: ["Build"]
+    task:
+      jobs:
+        - name: Run FV
+          commands:
+            - make image
+            - cd .. && git clone https://github.com/projectcalico/felix.git && cd felix
+            - JUST_A_MINUTE=true USE_TYPHA=true FV_TYPHAIMAGE=calico/typha:latest TYPHA_VERSION=latest make k8sfv-test
+
+  - name: 'Foss Checks'
+    dependencies: ["Build"]
+    task:
+      secrets:
+        - name: foss-api-key
+      jobs:
+        - name: Foss Checks
+          commands:
+            - if [ -z "${PULL_REQUEST_NUMBER}" ]; then make foss-checks; fi
+
+  - name: 'Push Images (non-PR builds only)'
+    dependencies: ["UTs", "FVs", "Foss Checks"]
+    skip:
+      # Only run on branches, not PRs.
+      when: "branch !~ '.+'"
+    task:
+      secrets:
+        - name: quay-robot-calico+semaphoreci
+        - name: docker
+      prologue:
+        commands:
+          - echo $DOCKER_TOKEN | docker login --username "$DOCKER_USER" --password-stdin
+          - echo $QUAY_TOKEN | docker login --username "$QUAY_USER" --password-stdin quay.io
+      jobs:
+        - name: Run CD
+          commands:
+            - export BRANCH_NAME=$SEMAPHORE_GIT_BRANCH
+            - if [ -z "${SEMAPHORE_GIT_PR_NUMBER}" ]; then make image-all cd CONFIRM=true; fi
+
+  - name: Trigger pin updates
+    dependencies: []
+    skip:
+      when: "(branch != 'master') and (branch !~ '^release-v\d*\.\d*')"
+    task:
+      secrets:
+        - name: semaphore-api
+      jobs:
+        - name: Trigger pin updates
+          commands:
+            - checkout
+            - make semaphore-run-auto-pin-update-workflows
+
+promotions:
+  # Run this manually via the semaphore UI if the cache is full
+  - name: Clear Cache
+    pipeline_file: clear_cache.yml
+  # Run the pin update process in case there were a backlog of pin update requests
+  - name: Update Pins
+    pipeline_file: update_pins.yml
+    auto_promote:
+      # If the block has passed and the branch is for master or a release branch then run the pin updates. Note that
+      # this doesn't try to restrict which release branches, as the presence of this auto promotion code means that
+      # it can handle updating the pins in this fashion.
+      when: "(result = 'passed') and ((branch = 'master') or (branch =~ '^release-v\d*\.\d*'))"

--- a/.semaphore/update_pins.yml
+++ b/.semaphore/update_pins.yml
@@ -1,0 +1,35 @@
+version: v1.0
+name: Trigger Pin Updates
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+global_job_config:
+  secrets:
+    - name: docker-hub
+    # Mount the github SSH secret for repositories.
+    - name: private-repo
+    # Mount a secret for pulling images from GCR.
+    - name: tigera-dev-ci-pull-credentials
+  prologue:
+    commands:
+      - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Correct permissions since they are too open by default:
+      - chmod 0600 ~/.keys/*
+      # Add the key to the ssh agent:
+      - ssh-add ~/.keys/*
+      # Login to docker in order to pull images.
+      - docker login --username casey@tigera.io -u _json_key -p "$(cat /home/semaphore/tigera-dev-ci.json)" https://gcr.io
+      - checkout
+
+blocks:
+  - name: 'Auto pin update'
+    task:
+      secrets:
+        - name: marvin-github-token
+      jobs:
+        - name: 'Auto pin update'
+          commands:
+            - CONFIRM=true make git-config
+            - CONFIRM=true GITHUB_TOKEN=${MARVIN_GITHUB_TOKEN} make trigger-auto-pin-update-process


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Semaphore v1 can no longer build Typha due to the docker account requirement.  Backport the Semaphore v2 build.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
