### PR TITLE
Automated cherry pick of #473: Fix make cd target to use correct tag for docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(BRANCH_NAME) EXCLUDEARCH="$(EXCLUDEARCH)"
-	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=${GIT_VERSION} EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) tag-images-all push-all push-manifests push-non-manifests IMAGETAG=$(shell git describe --tags --dirty --always --long --abbrev=12) EXCLUDEARCH="$(EXCLUDEARCH)"
 
 fv: k8sfv-test
 


### PR DESCRIPTION
Cherry pick of #473 on release-v3.17.

#473: Fix make cd target to use correct tag for docker images