### PR TITLE
[v3.17] Backport setting minimum TLS version to v1.2

### DIFF
--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -119,8 +119,8 @@ var (
 	}
 	v3Node = api.Update{
 		KVPair: model.KVPair{
-			Key:      model.ResourceKey{Name: "node1", Kind: v3.KindNode},
-			Value:    &v3.Node{
+			Key: model.ResourceKey{Name: "node1", Kind: v3.KindNode},
+			Value: &v3.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "1237",
 				},
@@ -131,8 +131,8 @@ var (
 	}
 	v3BGPPeer = api.Update{
 		KVPair: model.KVPair{
-			Key:      model.ResourceKey{Name: "peer1", Kind: v3.KindBGPPeer},
-			Value:    &v3.BGPPeer{
+			Key: model.ResourceKey{Name: "peer1", Kind: v3.KindBGPPeer},
+			Value: &v3.BGPPeer{
 				ObjectMeta: metav1.ObjectMeta{
 					ResourceVersion: "1238",
 				},
@@ -1179,11 +1179,8 @@ var _ = Describe("with server requiring TLS", func() {
 		}
 		// Connect with specified TLS options.
 		clientState := createClient(options)
-		if clientCertName != "" && !expectConnection {
-			// We're attempting a TLS connection but expecting it to fail.  That shows
-			// up as Start() returning an error.
-			Expect(clientState.startErr).To(HaveOccurred())
-		} else {
+		if clientCertName == "" || expectConnection {
+			// Expecting this connection to succeed so there should be no error from Start().
 			Expect(clientState.startErr).NotTo(HaveOccurred())
 		}
 
@@ -1208,14 +1205,17 @@ var _ = Describe("with server requiring TLS", func() {
 			}))
 			// Now get the client to disconnect.
 			clientState.clientCancel()
-		} else {
-			// Client connection should have failed, so should not see that state.
+		}
+
+		// For successful connections we just told the client to stop.  For unsuccessful connections
+		// it should detect the failure and stop on its own.
+		Eventually(connectionClosed).Should(BeClosed())
+
+		if !expectConnection {
+			// Client connection should have failed, so should not have got any updates.
 			Consistently(clientState.recorder.Status).Should(Equal(api.SyncStatus(0)))
 			Consistently(clientState.recorder.KVs).Should(Equal(map[string]api.Update{}))
 		}
-
-		// Synchronize with the client connection being closed.
-		Eventually(connectionClosed).Should(BeClosed())
 	}
 
 	testNonTLS := func() {

--- a/pkg/config/file_loader_test.go
+++ b/pkg/config/file_loader_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	"github.com/projectcalico/typha/pkg/config"
 )
 

--- a/pkg/snapcache/cache_test.go
+++ b/pkg/snapcache/cache_test.go
@@ -17,8 +17,9 @@ package snapcache_test
 import (
 	"strconv"
 
-	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 
 	"github.com/projectcalico/typha/pkg/snapcache"
 
@@ -118,11 +119,11 @@ var _ = Describe("Snapshot cache FV tests", func() {
 
 		BeforeEach(func() {
 			kvNodeRev10 = model.KVPair{
-				Key:      model.ResourceKey{Name: "node1", Kind: v3.KindNode},
-				Value:    &v3.Node{
+				Key: model.ResourceKey{Name: "node1", Kind: v3.KindNode},
+				Value: &v3.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						ResourceVersion: "10",
-						Name: "foo",
+						Name:            "foo",
 					},
 					Spec: v3.NodeSpec{
 						IPv4VXLANTunnelAddr: "10.0.0.1",
@@ -161,11 +162,11 @@ var _ = Describe("Snapshot cache FV tests", func() {
 			// Then send in another update with same value, and another value to make sure we generate another
 			// crumb.
 			kvNodeRev11 := model.KVPair{
-				Key:      model.ResourceKey{Name: "node1", Kind: v3.KindNode},
-				Value:    &v3.Node{
+				Key: model.ResourceKey{Name: "node1", Kind: v3.KindNode},
+				Value: &v3.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						ResourceVersion: "11",
-						Name: "foo",
+						Name:            "foo",
 					},
 					Spec: v3.NodeSpec{
 						IPv4VXLANTunnelAddr: "10.0.0.1",

--- a/pkg/syncclient/sync_client.go
+++ b/pkg/syncclient/sync_client.go
@@ -209,8 +209,9 @@ func (s *SyncerClient) connect(cxt context.Context) error {
 			return err
 		}
 		tlsConfig := tls.Config{Certificates: []tls.Certificate{cert}}
-		// go 1.13 defaults to TLS13, which causes some test issues. Set it to TLS12 for now.
-		tlsConfig.MaxVersion = tls.VersionTLS12
+		// Typha API is a private binary API so we can enforce a recent TLS variant without
+		// worrying about back-compatibility with old browsers (for example).
+		tlsConfig.MinVersion = tls.VersionTLS12
 
 		// Set InsecureSkipVerify true, because when it's false crypto/tls insists on
 		// verifying the server's hostname or IP address against tlsConfig.ServerName, and


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Backport of #457 

Increase minimum TLS version to v1.2 for improved security.

(cherry picked from commit 02cb7ab48db1576d286a5aca343b8e7f0b8e3bdd)

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
For improved security, then using TLS, the Felix-Typha API now requires a minimum TLS version of v1.2.
```
