### PR TITLE
Use new common cd formatting / pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,6 +14,8 @@ global_job_config:
   - name: docker-hub
   prologue:
     commands:
+      # make some room on the disk
+      - sudo rm -rf ~/.kiex ~/.phpbrew ~/.rbenv ~/.nvm ~/.kerl
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
       - checkout
       # Note that the 'cache restore' commands require that the "Build" block has been run. The "Build" block is what populates


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

`cd` dry run output using `make cd DRYRUN=true BRANCH_NAME=master | grep -P -v "^make|^echo|^#"`:
```
docker tag calico/typha:latest-amd64 quay.io/calico/typha:master
docker tag calico/typha:latest-amd64 calico/typha:master-amd64
docker tag calico/typha:latest-arm64 calico/typha:master-arm64
docker tag calico/typha:latest-ppc64le calico/typha:master-ppc64le
[DRY RUN] docker push quay.io/calico/typha:master
[DRY RUN] docker push calico/typha:master-amd64
[DRY RUN] docker push calico/typha:master-arm64
[DRY RUN] docker push calico/typha:master-ppc64le
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template calico/typha:master-ARCHVARIANT --target calico/typha:master
docker tag calico/typha:latest-amd64 quay.io/calico/typha:v3.19.0-12-g59d493f3141a
docker tag calico/typha:latest-amd64 calico/typha:v3.19.0-12-g59d493f3141a-amd64
docker tag calico/typha:latest-arm64 calico/typha:v3.19.0-12-g59d493f3141a-arm64
docker tag calico/typha:latest-ppc64le calico/typha:v3.19.0-12-g59d493f3141a-ppc64le
[DRY RUN] docker push quay.io/calico/typha:v3.19.0-12-g59d493f3141a
[DRY RUN] docker push calico/typha:v3.19.0-12-g59d493f3141a-amd64
[DRY RUN] docker push calico/typha:v3.19.0-12-g59d493f3141a-arm64
[DRY RUN] docker push calico/typha:v3.19.0-12-g59d493f3141a-ppc64le
[DRY RUN] docker run -t --entrypoint /bin/sh -v /home/brian/.docker/config.json:/root/.docker/config.json calico/go-build:v0.53 -c /usr/bin/manifest-tool push from-args --platforms linux/amd64,linux/arm64,linux/ppc64le --template calico/typha:v3.19.0-12-g59d493f3141a-ARCHVARIANT --target calico/typha:v3.19.0-12-g59d493f3141a
```

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
