### PR TITLE
Add an extra grace period for new connections

### DIFF
--- a/fv-tests/server_test.go
+++ b/fv-tests/server_test.go
@@ -978,6 +978,207 @@ var _ = Describe("With an in-process Server with long ping interval", func() {
 	})
 })
 
+var _ = Describe("With an in-process Server with short grace period", func() {
+	var (
+		cacheCxt     context.Context
+		cacheCancel  context.CancelFunc
+		cache        *snapcache.Cache
+		server       *syncserver.Server
+		serverCxt    context.Context
+		serverCancel context.CancelFunc
+		serverAddr   string
+		updIdx       int
+	)
+
+	BeforeEach(func() {
+		cache = snapcache.New(snapcache.Config{
+			// Set the batch size small so we can force new Breadcrumbs easily.
+			MaxBatchSize: 10,
+			// Reduce the wake up interval from the default to give us faster tear down.
+			WakeUpInterval: 50 * time.Millisecond,
+		})
+		server = syncserver.New(
+			map[syncproto.SyncerType]syncserver.BreadcrumbProvider{syncproto.SyncerTypeFelix: cache},
+			syncserver.Config{
+				PingInterval:                   10000 * time.Second,
+				PongTimeout:                    50000 * time.Second,
+				Port:                           syncserver.PortRandom,
+				DropInterval:                   1 * time.Second,
+				MaxFallBehind:                  1 * time.Second,
+				NewClientFallBehindGracePeriod: 1 * time.Second,
+			})
+		cacheCxt, cacheCancel = context.WithCancel(context.Background())
+		cache.Start(cacheCxt)
+		serverCxt, serverCancel = context.WithCancel(context.Background())
+		server.Start(serverCxt)
+		serverAddr = fmt.Sprintf("127.0.0.1:%d", server.Port())
+		updIdx = 0
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			serverCancel()
+			log.Info("Waiting for server to shut down")
+			server.Finished.Wait()
+			log.Info("Done waiting for server to shut down")
+		}
+		if cache != nil {
+			cacheCancel()
+		}
+	})
+
+	sendNUpdates := func(n int) map[string]api.Update {
+		expectedEndState := map[string]api.Update{}
+		cache.OnStatusUpdated(api.ResyncInProgress)
+		for i := 0; i < n; i++ {
+			update := api.Update{
+				KVPair: model.KVPair{
+					Key: model.GlobalConfigKey{
+						Name: fmt.Sprintf("foo%v", i+updIdx),
+					},
+					// Nice big value so that we can fill up the send queue.
+					Value: fmt.Sprintf("baz%vxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"+
+						"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", i),
+					Revision: fmt.Sprintf("%v", i+updIdx),
+				},
+				UpdateType: api.UpdateTypeKVNew,
+			}
+			path, err := model.KeyToDefaultPath(update.Key)
+			Expect(err).NotTo(HaveOccurred())
+			expectedEndState[path] = update
+			cache.OnUpdates([]api.Update{update})
+			updIdx += n
+		}
+		return expectedEndState
+	}
+
+	sendNUpdatesThenInSync := func(n int) map[string]api.Update {
+		expectedEndState := sendNUpdates(n)
+		cache.OnStatusUpdated(api.InSync)
+		return expectedEndState
+	}
+
+	Describe("with lots of KVs", func() {
+		const initialSnapshotSize = 10000
+		BeforeEach(func() {
+			sendNUpdatesThenInSync(initialSnapshotSize)
+		})
+
+		It("client should get a grace period after reading the snapshot", func() {
+			clientCxt, clientCancel := context.WithCancel(context.Background())
+			recorder := NewRecorder()
+
+			// Make the client block after it reads the first update.  This means the server will have started
+			// streaming the snapshot but it shouldn't be able to finish streaming the snapshot.  Blocking for
+			// >1s wastes the MaxFallBehind timeout so this client will need to rely on the
+			// NewClientFallBehindGracePeriod, which should kick in only once we've finished reading the snapshot.
+			recorder.BlockAfterNUpdates(1, 2500*time.Millisecond)
+
+			client := syncclient.New(
+				serverAddr,
+				"test-version",
+				"test-host",
+				"test-info",
+				recorder,
+				nil,
+			)
+			err := client.Start(clientCxt)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				clientCancel()
+				client.Finished.Wait()
+			}()
+
+			// Wait until the client reads its first KV so that we know the server has started streaming the
+			// first breadcrumb before we create a new one...
+			Eventually(recorder.Len, time.Second).Should(BeNumerically(">", 0))
+
+			// Make a breadcrumb 1s later.
+			time.Sleep(time.Second)
+			sendNUpdates(1)
+			// Make a breadcrumb 1s later.
+			time.Sleep(time.Second)
+			sendNUpdates(1)
+
+			// Client should wake up around now and start catching up.
+
+			// Make a breadcrumb 1s later.
+			time.Sleep(time.Second)
+			sendNUpdates(1)
+
+			Eventually(recorder.Len, 2*time.Second).Should(BeNumerically("==", initialSnapshotSize+3))
+		})
+
+		It("client should get disconnected if it falls behind after the grace period", func() {
+			clientCxt, clientCancel := context.WithCancel(context.Background())
+			recorder := NewRecorder()
+
+			// Make the client block after it reads the first update.  This means the server will have started
+			// streaming the snapshot but it shouldn't be able to finish streaming the snapshot.  Blocking for
+			// >1s wastes the MaxFallBehind timeout so this client will need to rely on the
+			// NewClientFallBehindGracePeriod, which should kick in only once we've finished reading the snapshot.
+			recorder.BlockAfterNUpdates(initialSnapshotSize+1, 2500*time.Millisecond)
+
+			client := syncclient.New(
+				serverAddr,
+				"test-version",
+				"test-host",
+				"test-info",
+				recorder,
+				nil,
+			)
+			err := client.Start(clientCxt)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() {
+				clientCancel()
+				client.Finished.Wait()
+			}()
+
+			// Wait until the snapshot is read.
+			Eventually(recorder.Len, time.Second).Should(BeNumerically("==", initialSnapshotSize))
+
+			// Make a breadcrumb.
+			time.Sleep(time.Second)
+			sendNUpdates(initialSnapshotSize)
+
+			// Client should read the first update from the above and then block.
+
+			// Make a breadcrumb 1s later.
+			time.Sleep(time.Second)
+			sendNUpdates(1)
+
+			// Make a breadcrumb 1s later.
+			time.Sleep(time.Second)
+			sendNUpdates(1)
+
+			// Client should wake up around now but be too far behind and get disconnected.
+
+			finishedC := make(chan struct{})
+			go func() {
+				client.Finished.Wait()
+				close(finishedC)
+			}()
+
+			Eventually(finishedC, 5*time.Second).Should(BeClosed())
+
+			// Should only have received at most the first two chunks.
+			Expect(recorder.Len()).To(BeNumerically(">", initialSnapshotSize))
+			Expect(recorder.Len()).To(BeNumerically("<=", initialSnapshotSize*2))
+		})
+	})
+})
+
 func getGauge(name string) (float64, error) {
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,10 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-ini/ini v0.0.0-20190327024845-3be5ad479f69 h1:uY1bb7icXBVknpjPIMjGsTFU/GTy8YUfLlfGouMCnn4=
 github.com/go-ini/ini v0.0.0-20190327024845-3be5ad479f69/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=

--- a/pkg/config/config_params.go
+++ b/pkg/config/config_params.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2017,2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2016-2017,2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
-
-	"time"
 
 	"github.com/projectcalico/libcalico-go/lib/apiconfig"
 )
@@ -115,12 +114,13 @@ type Config struct {
 
 	SnapshotCacheMaxBatchSize int `config:"int(1,);100"`
 
-	ServerMaxMessageSize              int           `config:"int(1,);100"`
-	ServerMaxFallBehindSecs           time.Duration `config:"seconds;90"`
-	ServerMinBatchingAgeThresholdSecs time.Duration `config:"seconds;0.01"`
-	ServerPingIntervalSecs            time.Duration `config:"seconds;10"`
-	ServerPongTimeoutSecs             time.Duration `config:"seconds;60"`
-	ServerPort                        int           `config:"port;0"`
+	ServerMaxMessageSize                 int           `config:"int(1,);100"`
+	ServerMaxFallBehindSecs              time.Duration `config:"seconds;90"`
+	ServerNewClientFallBehindGracePeriod time.Duration `config:"seconds;90"`
+	ServerMinBatchingAgeThresholdSecs    time.Duration `config:"seconds;0.01"`
+	ServerPingIntervalSecs               time.Duration `config:"seconds;10"`
+	ServerPongTimeoutSecs                time.Duration `config:"seconds;60"`
+	ServerPort                           int           `config:"port;0"`
 
 	// Server-side TLS config for Typha's communication with Felix.  If any of these are
 	// specified, they _all_ must be - except that either ClientCN or ClientURISAN may be left

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018,2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018,2020-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -383,20 +383,21 @@ func (t *TyphaDaemon) CreateServer() {
 	t.Server = syncserver.New(
 		t.CachesBySyncerType,
 		syncserver.Config{
-			MaxMessageSize:          t.ConfigParams.ServerMaxMessageSize,
-			MinBatchingAgeThreshold: t.ConfigParams.ServerMinBatchingAgeThresholdSecs,
-			MaxFallBehind:           t.ConfigParams.ServerMaxFallBehindSecs,
-			PingInterval:            t.ConfigParams.ServerPingIntervalSecs,
-			PongTimeout:             t.ConfigParams.ServerPongTimeoutSecs,
-			DropInterval:            t.ConfigParams.ConnectionDropIntervalSecs,
-			MaxConns:                t.ConfigParams.MaxConnectionsUpperLimit,
-			Port:                    t.ConfigParams.ServerPort,
-			HealthAggregator:        t.healthAggregator,
-			KeyFile:                 t.ConfigParams.ServerKeyFile,
-			CertFile:                t.ConfigParams.ServerCertFile,
-			CAFile:                  t.ConfigParams.CAFile,
-			ClientCN:                t.ConfigParams.ClientCN,
-			ClientURISAN:            t.ConfigParams.ClientURISAN,
+			MaxMessageSize:                 t.ConfigParams.ServerMaxMessageSize,
+			MinBatchingAgeThreshold:        t.ConfigParams.ServerMinBatchingAgeThresholdSecs,
+			MaxFallBehind:                  t.ConfigParams.ServerMaxFallBehindSecs,
+			NewClientFallBehindGracePeriod: t.ConfigParams.ServerNewClientFallBehindGracePeriod,
+			PingInterval:                   t.ConfigParams.ServerPingIntervalSecs,
+			PongTimeout:                    t.ConfigParams.ServerPongTimeoutSecs,
+			DropInterval:                   t.ConfigParams.ConnectionDropIntervalSecs,
+			MaxConns:                       t.ConfigParams.MaxConnectionsUpperLimit,
+			Port:                           t.ConfigParams.ServerPort,
+			HealthAggregator:               t.healthAggregator,
+			KeyFile:                        t.ConfigParams.ServerKeyFile,
+			CertFile:                       t.ConfigParams.ServerCertFile,
+			CAFile:                         t.ConfigParams.CAFile,
+			ClientCN:                       t.ConfigParams.ClientCN,
+			ClientURISAN:                   t.ConfigParams.ClientURISAN,
 		},
 	)
 }

--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2019,2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,13 +103,14 @@ func init() {
 }
 
 const (
-	defaultMaxMessageSize       = 100
-	defaultMaxFallBehind        = 90 * time.Second
-	defaultBatchingAgeThreshold = 100 * time.Millisecond
-	defaultPingInterval         = 10 * time.Second
-	defaultDropInterval         = 1 * time.Second
-	defaultMaxConns             = math.MaxInt32
-	PortRandom                  = -1
+	defaultMaxMessageSize                 = 100
+	defaultMaxFallBehind                  = 90 * time.Second
+	defaultNewClientFallBehindGracePeriod = 90 * time.Second
+	defaultBatchingAgeThreshold           = 100 * time.Millisecond
+	defaultPingInterval                   = 10 * time.Second
+	defaultDropInterval                   = 1 * time.Second
+	defaultMaxConns                       = math.MaxInt32
+	PortRandom                            = -1
 )
 
 type Server struct {
@@ -133,20 +134,21 @@ type BreadcrumbProvider interface {
 }
 
 type Config struct {
-	Port                    int
-	MaxMessageSize          int
-	MaxFallBehind           time.Duration
-	MinBatchingAgeThreshold time.Duration
-	PingInterval            time.Duration
-	PongTimeout             time.Duration
-	DropInterval            time.Duration
-	MaxConns                int
-	HealthAggregator        *health.HealthAggregator
-	KeyFile                 string
-	CertFile                string
-	CAFile                  string
-	ClientCN                string
-	ClientURISAN            string
+	Port                           int
+	MaxMessageSize                 int
+	MaxFallBehind                  time.Duration
+	NewClientFallBehindGracePeriod time.Duration
+	MinBatchingAgeThreshold        time.Duration
+	PingInterval                   time.Duration
+	PongTimeout                    time.Duration
+	DropInterval                   time.Duration
+	MaxConns                       int
+	HealthAggregator               *health.HealthAggregator
+	KeyFile                        string
+	CertFile                       string
+	CAFile                         string
+	ClientCN                       string
+	ClientURISAN                   string
 }
 
 const (
@@ -168,6 +170,13 @@ func (c *Config) ApplyDefaults() {
 			"default": defaultMaxFallBehind,
 		}).Info("Defaulting MaxFallBehind.")
 		c.MaxFallBehind = defaultMaxFallBehind
+	}
+	if c.NewClientFallBehindGracePeriod <= 0 {
+		log.WithFields(log.Fields{
+			"value":   c.NewClientFallBehindGracePeriod,
+			"default": defaultNewClientFallBehindGracePeriod,
+		}).Info("Defaulting MaxFallBehind.")
+		c.NewClientFallBehindGracePeriod = defaultNewClientFallBehindGracePeriod
 	}
 	if c.MinBatchingAgeThreshold <= 0 {
 		log.WithFields(log.Fields{
@@ -715,6 +724,8 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 		log.WithError(err).Info("Failed to send snapshot to client, tearing down connection.")
 		return
 	}
+	// Finished sending the snapshot, calculate the grace time for the client to catch up to a recent breadcrumb.
+	gracePeriodEndTime := time.Now().Add(h.config.NewClientFallBehindGracePeriod)
 
 	// Track the sync status reported in each Breadcrumb so we can send an update if it changes.
 	var lastSentStatus api.SyncStatus
@@ -739,6 +750,7 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 		return
 	}
 
+	loggedClientBehind := false
 	for h.cxt.Err() == nil {
 		// Wait for new Breadcrumbs.  If we're behind, we'll coalesce the deltas from multiple Breadcrumbs
 		// before exiting the loop.
@@ -767,12 +779,42 @@ func (h *connection) sendSnapshotAndUpdatesToClient(logCxt *log.Entry) {
 
 			// Check if we're too far behind the latest Breadcrumb.
 			if crumbAge > h.config.MaxFallBehind {
+				// Allow extra time for new clients to catch up after sending the snapshot.  If the snapshot was
+				// very large and clients are slow for some reason then we don't want to get stuck in a loop where
+				// clients connect, grab the snapshot, immediately end up behind and get disconnected.
+				//
+				// This has a secondary effect: under extreme overload where clients are falling behind we give
+				// them a grace period to apply the updates to the dataplane before we cut them off.  That means that
+				// Felix will still make progresseven though it's restarting, albeit with 90+s between dataplane
+				// updates.
+				if time.Now().After(gracePeriodEndTime) {
+					logCxt.WithFields(log.Fields{
+						"snapAge":        crumbAge,
+						"mySeqNo":        breadcrumb.SequenceNumber,
+						"latestSeqNo":    latestCrumb.SequenceNumber,
+						"mySnapshotSize": breadcrumb.KVs.Size(),
+					}).Warn("Client fell behind. Disconnecting.")
+					return
+				} else if !loggedClientBehind {
+					logCxt.WithFields(log.Fields{
+						"snapAge":        crumbAge,
+						"mySeqNo":        breadcrumb.SequenceNumber,
+						"latestSeqNo":    latestCrumb.SequenceNumber,
+						"gracePeriod":    h.config.NewClientFallBehindGracePeriod,
+						"mySnapshotSize": breadcrumb.KVs.Size(),
+					}).Warn("Client is a long way behind after sending snapshot; " +
+						"allowing grace period for it to catch up.")
+					loggedClientBehind = true
+				}
+			} else if loggedClientBehind && time.Now().After(gracePeriodEndTime) {
+				// Client caught up after being behind when we sent it a snapshot.
 				logCxt.WithFields(log.Fields{
-					"snapAge":     crumbAge,
-					"mySeqNo":     breadcrumb.SequenceNumber,
-					"latestSeqNo": latestCrumb.SequenceNumber,
-				}).Warn("Client fell behind. Disconnecting.")
-				return
+					"snapAge":        crumbAge,
+					"mySeqNo":        breadcrumb.SequenceNumber,
+					"latestSeqNo":    latestCrumb.SequenceNumber,
+					"mySnapshotSize": breadcrumb.KVs.Size(),
+				}).Info("Client was behind after sending snapshot but it has now caught up.")
+				loggedClientBehind = false // Avoid logging the "caught up" log on every loop.
 			}
 
 			if crumbAge < h.config.MinBatchingAgeThreshold && deltas == nil {

--- a/pkg/syncserver/syncserver_test.go
+++ b/pkg/syncserver/syncserver_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017,2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,14 +33,15 @@ var _ = Describe("With zero config", func() {
 	It("it should apply correct defaults", func() {
 		config.ApplyDefaults()
 		Expect(config).To(Equal(Config{
-			MaxMessageSize:          100,
-			MaxFallBehind:           90 * time.Second,
-			MinBatchingAgeThreshold: 100 * time.Millisecond,
-			PingInterval:            10 * time.Second,
-			PongTimeout:             60 * time.Second,
-			DropInterval:            time.Second,
-			MaxConns:                math.MaxInt32,
-			Port:                    5473,
+			MaxMessageSize:                 100,
+			MaxFallBehind:                  90 * time.Second,
+			NewClientFallBehindGracePeriod: 90 * time.Second,
+			MinBatchingAgeThreshold:        100 * time.Millisecond,
+			PingInterval:                   10 * time.Second,
+			PongTimeout:                    60 * time.Second,
+			DropInterval:                   time.Second,
+			MaxConns:                       math.MaxInt32,
+			Port:                           5473,
 		}))
 	})
 	It("should convert random port to 0", func() {


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
We've seen felix get cyclicly booted from the server, presumably
because sending the snapshot took an unexpectedly long time due
to CPU or netowrk contention.

Add an extra grace period for newly-connected clients so that
they get some time to catch up after the snapshot is sent. Hopefully,
that will solve the problem outright but it also has the side effect
of giving the new felix some time to update the dataplane before we
kill the Typha connection.  This ensures that it makes progress
even if it's restarting.

## Todos
- [x] Unit tests (full coverage)
- [x] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Typha now gives newly connected clients an extra grace period to catch up after sending the snapshot.  Should reduce the possibility of cyclic disconnects.
```
