### PR TITLE
Automated cherry pick of #635: Fix release image tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ release-build: release-prereqs clean
 ifneq ($(VERSION), $(GIT_VERSION))
 	$(error Attempt to build $(VERSION) from $(GIT_VERSION))
 endif
-	$(MAKE) image-all
+	$(MAKE) image-all RELEASE=true
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=$(VERSION)
 	$(MAKE) retag-build-images-with-registries RELEASE=true IMAGETAG=latest
 


### PR DESCRIPTION
Cherry pick of #635 on release-v3.20.

#635: Fix release image tagging