### PR TITLE
fix: specify platform in docker build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ $(TYPHA_IMAGE): bin/calico-typha-$(ARCH) register
 	mkdir -p docker-image/bin
 	cp bin/calico-typha-$(ARCH) docker-image/bin/
 	cp LICENSE docker-image/
-	docker build --pull -t $(TYPHA_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) --file ./docker-image/Dockerfile.$(ARCH) docker-image
+	docker build --pull --platform linux/$(ARCH) -t $(TYPHA_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) --file ./docker-image/Dockerfile.$(ARCH) docker-image
 ifeq ($(ARCH),amd64)
 	docker tag $(TYPHA_IMAGE):latest-$(ARCH) $(TYPHA_IMAGE):latest
 endif


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

The image architecture is inconsistent with the tag name, e.g.

```
docker manifest inspect --verbose quay.io/calico/cni:master-arm64
{
	"Ref": "quay.io/calico/typha:master-arm64",
	"Descriptor": {
		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
		"digest": "sha256:9965441aba695c88ff6d52585fffe4cacc2401d51cf5c8e8c3d4c4233763a5d3",
		"size": 946,
		"platform": {
			"architecture": "amd64",
			"os": "linux"
		}
	},
...
```

After specifying `--platform` to `docker build` command:

```
{
	"Ref": "chewong/typha:master-linux-arm64",
	"Descriptor": {
		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
		"digest": "sha256:0817cff4cb8c52f87401b7b85bbd122478361a7afd8e0bd47e559e30f071a36a",
		"size": 738,
		"platform": {
			"architecture": "arm64",
			"os": "linux"
		}
	},
...
```

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
