### PR TITLE
Automated cherry pick of #694: Restrict Typha server to FIPS compliant cipher suites

### DIFF
--- a/pkg/syncserver/sync_server.go
+++ b/pkg/syncserver/sync_server.go
@@ -308,6 +308,9 @@ func (s *Server) serve(cxt context.Context) {
 		// worrying about back-compatibility with old browsers (for example).
 		tlsConfig.MinVersion = tls.VersionTLS12
 
+		// Set allowed cipher suites.
+		tlsConfig.CipherSuites = s.allowedCiphers()
+
 		// Arrange for server to verify the clients' certificates.
 		logCxt.Info("Will verify client certificates")
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
@@ -486,6 +489,19 @@ func (s *Server) governNumberOfConnections(cxt context.Context) {
 		case <-healthTicks:
 			s.reportHealth()
 		}
+	}
+}
+
+// allowedCiphers returns the set of allowed cipher suites for the server.
+// The list is taken from https://github.com/golang/go/blob/dev.boringcrypto.go1.13/src/crypto/tls/boring.go#L54
+func (s *Server) allowedCiphers() []uint16 {
+	return []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #694 on release-v3.21.

#694: Restrict Typha server to FIPS compliant cipher suites

# Original PR Body below

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Restrict Typha server to FIPS compliant cipher suites. 
```